### PR TITLE
Adds LCD1602 shield support

### DIFF
--- a/k3ng_keyer.ino
+++ b/k3ng_keyer.ino
@@ -359,6 +359,10 @@ New fetures in this stable release:
   #include "keyer_features_and_options_open_interface.h"
 #endif
 
+#ifdef HARDWARE_LCD1602_N07DH
+  #include "keyer_features_and_options_lcd1602_n07dh.h"
+#endif
+
 #ifndef HARDWARE_CUSTOM
   #include "keyer_features_and_options.h"
 #endif
@@ -374,6 +378,11 @@ New fetures in this stable release:
 #ifdef HARDWARE_OPEN_INTERFACE
   #include "keyer_pin_settings_open_interface.h"
   #include "keyer_settings_open_interface.h"
+#endif
+
+#ifdef HARDWARE_LCD1602_N07DH
+  #include "keyer_pin_settings_lcd1602_n07dh.h"
+  #include "keyer_settings_lcd1602_n07dh.h"
 #endif
 
 #ifndef HARDWARE_CUSTOM

--- a/keyer_features_and_options_lcd1602_n07dh.h
+++ b/keyer_features_and_options_lcd1602_n07dh.h
@@ -1,0 +1,71 @@
+// This file is for the LinkSprite SHD_LCD_1602 Rev A and Rev B Arduino shield
+// also sold as Maplin N07DH in the UK
+// http://linksprite.com/wiki/index.php5?title=16_X_2_LCD_Keypad_Shield_for_Arduino
+
+// compile time features and options - comment or uncomment to add or delete features
+// FEATURES add more bytes to the compiled binary, OPTIONS change code behavior
+
+#define FEATURE_COMMAND_BUTTONS
+#define FEATURE_COMMAND_LINE_INTERFACE        // (this no longer requires FEATURE_SERIAL)
+//#define FEATURE_MEMORIES
+//#define FEATURE_MEMORY_MACROS
+#define FEATURE_WINKEY_EMULATION    // disabling Automatic Software Reset is highly recommended (see documentation) (this no longer requires FEATURE_SERIAL)
+//#define FEATURE_BEACON
+//#define FEATURE_CALLSIGN_RECEIVE_PRACTICE
+//#define FEATURE_POTENTIOMETER         // do not enable unless you have a potentiometer connected, otherwise noise will falsely trigger wpm changes
+//#define FEATURE_SERIAL_HELP
+//#define FEATURE_HELL
+//#define FEATURE_PS2_KEYBOARD        // Use a PS2 keyboard to send code - Change keyboard layout (non-US) in K3NG_PS2Keyboard.h.  Additional options below.
+//#define FEATURE_USB_KEYBOARD          // Use a USB keyboard to send code - Uncomment three lines in k3ng_keyer.ino (search for note_usb_uncomment_lines)
+//#define FEATURE_DEAD_OP_WATCHDOG
+//#define FEATURE_AUTOSPACE
+//#define FEATURE_FARNSWORTH
+//#define FEATURE_DL2SBA_BANKSWITCH       // Switch memory banks feature as described here: http://dl2sba.com/index.php?option=com_content&view=article&id=131:nanokeyer&catid=15:shack&Itemid=27#english
+#define FEATURE_LCD_4BIT                // classic LCD disidefplay using 4 I/O lines
+//#define FEATURE_LCD_ADAFRUIT_I2C          // Adafruit I2C LCD display using MCP23017 at addr 0x20
+//#define FEATURE_LCD_YDv1                // YourDuino I2C LCD display with old LCM 1602 V1 ic
+//#define FEATURE_CW_DECODER
+//#define FEATURE_SLEEP                   // go to sleep after x minutes to conserve battery power
+//#define FEATURE_ROTARY_ENCODER          // rotary encoder speed control
+//#define FEATURE_CMOS_SUPER_KEYER_IAMBIC_B_TIMING
+//#define FEATURE_DIT_DAH_BUFFER_CONTROL
+//#define FEATURE_HI_PRECISION_LOOP_TIMING
+//#define FEATURE_USB_MOUSE                // Uncomment three lines in k3ng_keyer.ino (search for note_usb_uncomment_lines)
+//#define FEATURE_CAPACITIVE_PADDLE_PINS  // remove the bypass capacitors on the paddle_left and paddle_right lines when using capactive paddles
+//#define FEATURE_LED_RING                // Mayhew Labs Led Ring support
+//#define FEATURE_ALPHABET_SEND_PRACTICE  // enables command mode S command - created by Ryan, KC2ZWM
+//#define FEATURE_PTT_INTERLOCK 
+//#define FEATURE_QLF
+
+//#define OPTION_SUPPRESS_SERIAL_BOOT_MSG
+#define OPTION_INCLUDE_PTT_TAIL_FOR_MANUAL_SENDING
+#define OPTION_EXCLUDE_PTT_HANG_TIME_FOR_MANUAL_SENDING
+//#define OPTION_SERIAL_PORT_DEFAULT_WINKEY_EMULATION  // Use when activating both FEATURE_WINKEY_EMULATION and FEATURE_COMMAND_LINE_INTERFACE simultaneously.  This will make Winkey emulation be the default at boot up; hold command button down at boot up to activate CLI mode
+//#define OPTION_WINKEY_DISCARD_BYTES_AT_STARTUP     // if ASR is not disabled, you may need this to discard errant serial port bytes at startup
+//#define OPTION_WINKEY_STRICT_EEPROM_WRITES_MAY_WEAR_OUT_EEPROM // with this activated the unit will write non-volatile settings to EEPROM when set by Winkey commands
+//#define OPTION_WINKEY_SEND_WORDSPACE_AT_END_OF_BUFFER
+#define OPTION_WINKEY_STRICT_HOST_OPEN               // require an admin host open Winkey command before doing any other commands
+#define OPTION_WINKEY_2_SUPPORT                      // comment out to revert to Winkey version 1 emulation
+//#define OPTION_WINKEY_EXTENDED_COMMANDS            // in development
+#define OPTION_WINKEY_SEND_BREAKIN_STATUS_BYTE       // additional code to check_dit_paddle() and check_dah_paddle() to send 0xC2 status byte when paddles are hit
+#define OPTION_WINKEY_INTERRUPTS_MEMORY_REPEAT
+//#define OPTION_WINKEY_2_HOST_CLOSE_NO_SERIAL_PORT_RESET  // activate this when using Winkey 2 emulation and Win-Test
+//#define OPTION_WINKEY_FREQUENT_STATUS_REPORT         // activate this to make Winkey emulation play better with RUMlog and RUMped
+//#define OPTION_REVERSE_BUTTON_ORDER                // This is mainly for the DJ0MY NanoKeyer http://nanokeyer.wordpress.com/
+#define OPTION_PROG_MEM_TRIM_TRAILING_SPACES         // trim trailing spaces from memory when programming in command mode
+#define OPTION_DIT_PADDLE_NO_SEND_ON_MEM_RPT         // this makes dit paddle memory interruption a little smoother
+//#define OPTION_MORE_DISPLAY_MSGS                     // additional optional display messages - comment out to save memory
+//#define OPTION_N1MM_WINKEY_TAB_BUG_WORKAROUND        // enable this to ignore the TAB key in the Send CW window (this breaks SO2R functionality in N1MM)
+//#define OPTION_WATCHDOG_TIMER                        // this enables a four second ATmega48/88/168/328 watchdog timer; use for unattended/remote operation only
+//#define OPTION_MOUSE_MOVEMENT_PADDLE               // experimental (just fooling around) - mouse movement will act like a paddle
+//#define OPTION_NON_ENGLISH_EXTENSIONS  // add support for additional CW characters (i.e. À, Å, Þ, etc.)
+//#define OPTION_KEEP_PTT_KEYED_WHEN_CHARS_BUFFERED    // this option keeps PTT high if there are characters buffered from the keyboard, the serial interface, or Winkey
+//#define OPTION_DISPLAY_NON_ENGLISH_EXTENSIONS  // LCD display suport for non-English (NO/DK/DE) characters - Courtesy of OZ1JHM
+//#define OPTION_UNKNOWN_CHARACTER_ERROR_TONE
+//#define OPTION_DO_NOT_SAY_HI
+//#define OPTION_USE_ORIGINAL_VERSION_2_1_PS2KEYBOARD_LIB //use version 2.1 PS2Keyboard.h and PS2Keyboard.cpp for FEATURE_PS2_KEYBOARD
+//#define OPTION_PS2_NON_ENGLISH_CHAR_LCD_DISPLAY_SUPPORT // makes some non-English characters from the PS2 keyboard display correctly in the LCD display (donated by Marcin sp5iou)
+//#define OPTION_PS2_KEYBOARD_RESET // reset the PS2 keyboard upon startup with 0xFF (contributed by Bill, W9BEL)
+//#define OPTION_SAVE_MEMORY_NANOKEYER
+//#define OPTION_WINKEY_IGNORE_FIRST_STATUS_REQUEST     // DEBUG PURPOSES ONLY!!!
+

--- a/keyer_hardware.h
+++ b/keyer_hardware.h
@@ -12,11 +12,11 @@
 //#define HARDWARE_NANOKEYER_REV_B   // https://nanokeyer.wordpress.com/nanokeyer-info/  files: keyer_pin_settings_nanokeyer_rev_b.h, keyer_features_and_options_nanokeyer_rev_b.h, keyer_settings_nanokeyer_rev_b.h
 //#define HARDWARE_OPEN_INTERFACE   // http://remoteqth.com/open-interface.php   files: keyer_pin_settings_open_interface.h, keyer_features_and_options_open_interface.h, keyer_settings_open_interface.h
 //#define HARDWARE_ARDUINO_DUE   
-
+//#define HARDWARE_LCD1602_N07DH      // http://linksprite.com/wiki/index.php5?title=16_X_2_LCD_Keypad_Shield_for_Arduino
 
 
 // do not touch anything below this line
 
-#if defined(HARDWARE_NANOKEYER_REV_B) || defined(HARDWARE_OPEN_INTERFACE)
+#if defined(HARDWARE_NANOKEYER_REV_B) || defined(HARDWARE_OPEN_INTERFACE) || defined(HARDWARE_LCD1602_N07DH)
 #define HARDWARE_CUSTOM
 #endif

--- a/keyer_pin_settings_lcd1602_n07dh.h
+++ b/keyer_pin_settings_lcd1602_n07dh.h
@@ -1,0 +1,58 @@
+// This file is for the LinkSprite SHD_LCD_1602 Rev A and Rev B Arduino shield
+// also sold as Maplin N07DH in the UK
+// http://linksprite.com/wiki/index.php5?title=16_X_2_LCD_Keypad_Shield_for_Arduino
+
+/* Pins - you must review these and configure ! */
+#ifndef keyer_pin_settings_h
+#define paddle_left 2
+#define paddle_right 3
+#define tx_key_line_1 11       // (high = key down/tx on)
+#define tx_key_line_2 12
+#define tx_key_line_3 0
+#define tx_key_line_4 0
+#define tx_key_line_5 0
+#define tx_key_line_6 0
+#define sidetone_line 10         // connect a speaker for sidetone
+#define potentiometer A1        // Speed potentiometer (0 to 5 V) Use pot from 1k to 10k
+#define ptt_tx_1 0              // PTT ("push to talk") lines
+#define ptt_tx_2 0              //   Can be used for keying fox transmitter, T/R switch, or keying slow boatanchors
+#define ptt_tx_3 0              //   These are optional - set to 0 if unused
+#define ptt_tx_4 0
+#define ptt_tx_5 0
+#define ptt_tx_6 0
+#define cw_decoder_pin A5 //A3
+#define tx_key_dit 0            // if defined, goes high for dit (any transmitter)
+#define tx_key_dah 0            // if defined, goes high for dah (any transmitter)
+
+#ifdef FEATURE_COMMAND_BUTTONS
+#define analog_buttons_pin A0
+#define command_mode_active_led 0
+#endif //FEATURE_COMMAND_BUTTONS
+
+
+//lcd pins
+#ifdef FEATURE_LCD_4BIT
+#define lcd_rs 8
+#define lcd_enable 9
+#define lcd_d4 4
+#define lcd_d5 5
+#define lcd_d6 6
+#define lcd_d7 7
+#endif //FEATURE_LCD_4BIT
+#endif //keyer_pin_settings_h
+
+//ps2 keyboard pins
+#ifdef FEATURE_PS2_KEYBOARD
+#define ps2_keyboard_data A3
+#define ps2_keyboard_clock 3    // this must be on an interrupt capable pin!
+#endif //FEATURE_PS2_KEYBOARD
+
+#ifdef FEATURE_ALPHABET_SEND_PRACTICE
+#define correct_answer_led 0
+#define wrong_answer_led 0
+#endif //FEATURE_ALPHABET_SEND_PRACTICE
+
+#ifdef FEATURE_PTT_INTERLOCK
+#define ptt_interlock 0  // this pin disables PTT and TX KEY
+#endif //FEATURE_PTT_INTERLOCK
+

--- a/keyer_settings_lcd1602_n07dh.h
+++ b/keyer_settings_lcd1602_n07dh.h
@@ -1,0 +1,260 @@
+// This file is for the LinkSprite SHD_LCD_1602 Rev A and Rev B Arduino shield
+// also sold as Maplin N07DH in the UK
+// http://linksprite.com/wiki/index.php5?title=16_X_2_LCD_Keypad_Shield_for_Arduino
+
+// Initial and hardcoded settings
+#define initial_speed_wpm 26             // "factory default" keyer speed setting
+#define initial_sidetone_freq 600        // "factory default" sidetone frequency setting
+#define hz_high_beep 1500                // frequency in hertz of high beep
+#define hz_low_beep 400                  // frequency in hertz of low beep
+#define initial_dah_to_dit_ratio 300     // 300 = 3 / normal 3:1 ratio
+#define initial_ptt_lead_time_tx1 0         // PTT lead time in mS
+#define initial_ptt_tail_time_tx1 10         // PTT tail time in mS
+#define initial_ptt_lead_time_tx2 0         // PTT lead time in mS
+#define initial_ptt_tail_time_tx2 10         // PTT tail time in mS
+#define initial_ptt_lead_time_tx3 0         // PTT lead time in mS
+#define initial_ptt_tail_time_tx3 10         // PTT tail time in mS
+#define initial_ptt_lead_time_tx4 0         // PTT lead time in mS
+#define initial_ptt_tail_time_tx4 10         // PTT tail time in mS
+#define initial_ptt_lead_time_tx5 0         // PTT lead time in mS
+#define initial_ptt_tail_time_tx5 10         // PTT tail time in mS
+#define initial_ptt_lead_time_tx6 0         // PTT lead time in mS
+#define initial_ptt_tail_time_tx6 10         // PTT tail time in mS
+#define initial_qrss_dit_length 1        // QRSS dit length in seconds
+#define initial_pot_wpm_low_value 13     // Potentiometer WPM fully CCW
+#define initial_pot_wpm_high_value 35    // Potentiometer WPM fully CW
+#define wpm_limit_low 5
+#define wpm_limit_high 60
+#define potentiometer_change_threshold 1 // don't change the keyer speed until pot wpm has changed more than this
+#define default_serial_baud_rate 115200
+#define send_buffer_size 150
+#define default_length_letterspace 3
+#define default_length_wordspace 7
+#define default_keying_compensation 0    // number of milliseconds to extend all dits and dahs - for QSK on boatanchors
+#define default_first_extension_time 0   // number of milliseconds to extend first sent dit or dah
+#define default_pot_full_scale_reading 1023
+#define default_weighting 50             // 50 = weighting factor of 1 (normal)
+#define default_ptt_hang_time_wordspace_units 0.0
+#define memory_area_start 30             // the eeprom location where memory space starts
+#define memory_area_end 1023             // the eeprom location where memory space ends
+#define winkey_c0_wait_time 1            // the number of milliseconds to wait to send 0xc0 byte after send buffer has been sent
+#define winkey_command_timeout_ms 5000
+#define winkey_discard_bytes_startup 3   // this is used if OPTION_WINKEY_DISCARD_BYTES_AT_STARTUP is enabled above
+#define winkey_xoff_threshold 20         // the number of chars in the buffer when we begin sending XOFFs
+#define winkey_xon_threshold 10          // the number of chars in the buffer below which we deactivate XOFF
+#define default_memory_repeat_time 3000  // time in milliseconds
+#define lcd_columns 16
+#define lcd_rows 2
+#define hell_pixel_microseconds 4025
+#define program_memory_limit_consec_spaces 1
+#define serial_leading_zeros 1            // set to 1 to activate leading zeros in serial numbers (i.e. #1 = 001)
+#define serial_cut_numbers 0              // set to 1 to activate cut numbers in serial numbers (i.e. #10 = 1T, #19 = 1N)
+#define go_to_sleep_inactivity_time 10    // minutes - FEATURE_SLEEP
+#define default_cmos_super_keyer_iambic_b_timing_percent 33 // use with FEATURE_CMOS_SUPER_KEYER_IAMBIC_B_TIMING; should be between 0 to 99 % (0% = true iambic b;100% = iambic a behavior)
+#define cw_echo_timing_factor 0.25
+#define potentiometer_always_on 0
+#define ptt_interlock_check_every_ms 100
+#define ptt_interlock_active_state HIGH
+#define unknown_cw_character '*'
+
+#ifdef FEATURE_COMMAND_BUTTONS
+#define analog_buttons_number_of_buttons 4
+#define analog_buttons_r1 10
+#define analog_buttons_r2 1
+#endif
+
+
+#if defined(FEATURE_COMMAND_BUTTONS) &&  !defined(FEATURE_PS2_KEYBOARD) && !defined(FEATURE_USB_KEYBOARD) && !defined(FEATURE_COMMAND_LINE_INTERFACE) && !defined(FEATURE_WINKEY_EMULATION)
+#define number_of_memories byte(analog_buttons_number_of_buttons-1)
+#else
+#define number_of_memories byte(12)
+#endif
+
+#ifdef FEATURE_CAPACITIVE_PADDLE_PINS
+#define capacitance_threshold 2
+#endif //FEATURE_CAPACITIVE_PADDLE_PINS
+
+#ifdef FEATURE_LED_RING
+#define led_ring_low_limit 10
+#define led_ring_high_limit 50
+#endif //FEATURE_LED_RING
+
+#ifdef FEATURE_QLF
+#define qlf_dit_max 125
+#define qlf_dit_min 75
+#define qlf_dah_max 200
+#define qlf_dah_min 100
+#define qlf_on_by_default 0
+#endif //FEATURE_QLF
+
+// Variable macros
+#define STRAIGHT 1
+#define IAMBIC_B 2
+#define IAMBIC_A 3
+#define BUG 4
+#define ULTIMATIC 5
+
+#define PADDLE_NORMAL 0
+#define PADDLE_REVERSE 1
+
+#define KEYER_NORMAL 0
+#define BEACON 1
+#define KEYER_COMMAND_MODE 2
+
+#define OMIT_LETTERSPACE 1
+
+#define SIDETONE_OFF 0
+#define SIDETONE_ON 1
+#define SIDETONE_PADDLE_ONLY 2
+
+#define SENDING_NOTHING 0
+#define SENDING_DIT 1
+#define SENDING_DAH 2
+
+#define SPEED_NORMAL 0
+#define SPEED_QRSS 1
+
+#define CW 0
+#define HELL 1
+
+#ifdef FEATURE_PS2_KEYBOARD
+#define PS2_KEYBOARD_NORMAL 0
+#endif //FEATURE_PS2_KEYBOARD
+
+#define SERIAL_NORMAL 0
+#define SERIAL_WINKEY_EMULATION 1
+
+#define SERIAL_SEND_BUFFER_SPECIAL_START 13
+#define SERIAL_SEND_BUFFER_WPM_CHANGE 14        
+#define SERIAL_SEND_BUFFER_PTT_ON 15            
+#define SERIAL_SEND_BUFFER_PTT_OFF 16           
+#define SERIAL_SEND_BUFFER_TIMED_KEY_DOWN 17    
+#define SERIAL_SEND_BUFFER_TIMED_WAIT 18        
+#define SERIAL_SEND_BUFFER_NULL 19              
+#define SERIAL_SEND_BUFFER_PROSIGN 20           
+#define SERIAL_SEND_BUFFER_HOLD_SEND 21         
+#define SERIAL_SEND_BUFFER_HOLD_SEND_RELEASE 22 
+#define SERIAL_SEND_BUFFER_MEMORY_NUMBER 23
+#define SERIAL_SEND_BUFFER_SPECIAL_END 24
+
+#define SERIAL_SEND_BUFFER_NORMAL 0
+#define SERIAL_SEND_BUFFER_TIMED_COMMAND 1
+#define SERIAL_SEND_BUFFER_HOLD 2
+
+#ifdef FEATURE_WINKEY_EMULATION
+#define WINKEY_NO_COMMAND_IN_PROGRESS 0
+#define WINKEY_UNBUFFERED_SPEED_COMMAND 1
+#define WINKEY_UNSUPPORTED_COMMAND 2
+#define WINKEY_POINTER_COMMAND 3
+#define WINKEY_ADMIN_COMMAND 4
+#define WINKEY_PAUSE_COMMAND 5
+#define WINKEY_KEY_COMMAND 6
+#define WINKEY_SETMODE_COMMAND 7
+#define WINKEY_SIDETONE_FREQ_COMMAND 8
+#define WINKEY_ADMIN_COMMAND_ECHO 9
+#define WINKEY_BUFFERED_SPEED_COMMAND 10
+#define WINKEY_DAH_TO_DIT_RATIO_COMMAND 11
+#define WINKEY_KEYING_COMPENSATION_COMMAND 12
+#define WINKEY_FIRST_EXTENSION_COMMAND 13
+#define WINKEY_PTT_TIMES_PARM1_COMMAND 14
+#define WINKEY_PTT_TIMES_PARM2_COMMAND 15
+#define WINKEY_SET_POT_PARM1_COMMAND 16
+#define WINKEY_SET_POT_PARM2_COMMAND 17
+#define WINKEY_SET_POT_PARM3_COMMAND 18
+#define WINKEY_SOFTWARE_PADDLE_COMMAND 19
+#define WINKEY_CANCEL_BUFFERED_SPEED_COMMAND 20
+#define WINKEY_BUFFFERED_PTT_COMMMAND 21
+#define WINKEY_HSCW_COMMAND 22
+#define WINKEY_BUFFERED_HSCW_COMMAND 23
+#define WINKEY_WEIGHTING_COMMAND 24
+#define WINKEY_KEY_BUFFERED_COMMAND 25
+#define WINKEY_WAIT_BUFFERED_COMMAND 26
+#define WINKEY_POINTER_01_COMMAND 27
+#define WINKEY_POINTER_02_COMMAND 28
+#define WINKEY_POINTER_03_COMMAND 29
+#define WINKEY_FARNSWORTH_COMMAND 30
+#define WINKEY_MERGE_COMMAND 31
+#define WINKEY_MERGE_PARM_2_COMMAND 32
+#define WINKEY_SET_PINCONFIG_COMMAND 33
+#define WINKEY_EXTENDED_COMMAND 34
+#ifdef OPTION_WINKEY_2_SUPPORT
+#define WINKEY_SEND_MSG 35
+#endif //OPTION_WINKEY_2_SUPPORT
+#define WINKEY_LOAD_SETTINGS_PARM_1_COMMAND 101
+#define WINKEY_LOAD_SETTINGS_PARM_2_COMMAND 102
+#define WINKEY_LOAD_SETTINGS_PARM_3_COMMAND 103
+#define WINKEY_LOAD_SETTINGS_PARM_4_COMMAND 104
+#define WINKEY_LOAD_SETTINGS_PARM_5_COMMAND 105
+#define WINKEY_LOAD_SETTINGS_PARM_6_COMMAND 106
+#define WINKEY_LOAD_SETTINGS_PARM_7_COMMAND 107
+#define WINKEY_LOAD_SETTINGS_PARM_8_COMMAND 108
+#define WINKEY_LOAD_SETTINGS_PARM_9_COMMAND 109
+#define WINKEY_LOAD_SETTINGS_PARM_10_COMMAND 110
+#define WINKEY_LOAD_SETTINGS_PARM_11_COMMAND 111
+#define WINKEY_LOAD_SETTINGS_PARM_12_COMMAND 112
+#define WINKEY_LOAD_SETTINGS_PARM_13_COMMAND 113
+#define WINKEY_LOAD_SETTINGS_PARM_14_COMMAND 114
+#define WINKEY_LOAD_SETTINGS_PARM_15_COMMAND 115
+
+#define HOUSEKEEPING 0
+#define SERVICE_SERIAL_BYTE 1
+#endif //FEATURE_WINKEY_EMULATION
+
+#define AUTOMATIC_SENDING 0
+#define MANUAL_SENDING 1
+
+#define ULTIMATIC_NORMAL 0
+#define ULTIMATIC_DIT_PRIORITY 1
+#define ULTIMATIC_DAH_PRIORITY 2
+
+#ifdef FEATURE_WINKEY_EMULATION
+// alter these below to map alternate sidetones for Winkey interface protocol emulation
+#ifdef OPTION_WINKEY_2_SUPPORT
+#define WINKEY_SIDETONE_1 3759
+#define WINKEY_SIDETONE_2 1879
+#define WINKEY_SIDETONE_3 1252
+#define WINKEY_SIDETONE_4 940
+#define WINKEY_SIDETONE_5 752
+#define WINKEY_SIDETONE_6 625
+#define WINKEY_SIDETONE_7 535
+#define WINKEY_SIDETONE_8 469
+#define WINKEY_SIDETONE_9 417
+#define WINKEY_SIDETONE_10 375
+#else //OPTION_WINKEY_2_SUPPORT
+#define WINKEY_SIDETONE_1 4000
+#define WINKEY_SIDETONE_2 2000
+#define WINKEY_SIDETONE_3 1333
+#define WINKEY_SIDETONE_4 1000
+#define WINKEY_SIDETONE_5 800
+#define WINKEY_SIDETONE_6 666
+#define WINKEY_SIDETONE_7 571
+#define WINKEY_SIDETONE_8 500
+#define WINKEY_SIDETONE_9 444
+#define WINKEY_SIDETONE_10 400
+#endif //OPTION_WINKEY_2_SUPPORT
+
+#define WINKEY_1_REPORT_VERSION_NUMBER 10
+#define WINKEY_2_REPORT_VERSION_NUMBER 23
+
+// alter these to map to alternate hang time wordspace units
+#define WINKEY_HANG_TIME_1_0 1.0
+#define WINKEY_HANG_TIME_1_33 1.33
+#define WINKEY_HANG_TIME_1_66 1.66
+#define WINKEY_HANG_TIME_2_0 2.0
+
+#endif //FEATURE_WINKEY_EMULATION
+
+#define PRINTCHAR 0
+#define NOPRINT 1
+
+#define MAIN_SERIAL_PORT &Serial
+
+#ifdef DEBUG_AUX_SERIAL_PORT
+#define DEBUG_AUX_SERIAL_PORT &Serial1
+#define DEBUG_AUX_SERIAL_PORT_BAUD 115200
+#endif //DEBUG_AUX_SERIAL_PORT
+
+#define CW_DECODER_SCREEN_COLUMNS 40        // word wrap at this many columns
+#define CW_DECODER_SPACE_PRINT_THRESH 4.5   // print space if no tone for this many element lengths
+#define CW_DECODER_SPACE_DECODE_THRESH 2.0  // invoke character decode if no tone for this many element lengths
+#define CW_DECODER_NOISE_FILTER 20          // ignore elements shorter than this (mS)


### PR DESCRIPTION
This adds support for http://linksprite.com/wiki/index.php5?title=16_X_2_LCD_Keypad_Shield_for_Arduino aka http://www.maplin.co.uk/p/16x2-lcd-shield-for-arduino-n07dh which I picked up this afternoon. Maybe useful? Not sure how the command buttons are expected to function, but I am able to enter command mode and change WPM with current code using the "Right" button. Thank you for a great project!