### PR TITLE
To compile for Sparkfun ProMicro and Maple mini.

### DIFF
--- a/keyer_dependencies.h
+++ b/keyer_dependencies.h
@@ -10,7 +10,7 @@
   #define FEATURE_SERIAL
 #endif
 
-#if defined(HARDWARE_ARDUINO_DUE) && !defined(FEATURE_EEPROM_E24C1024) && defined(FEATURE_MEMORIES)
+#if defined(ARDUINO_SAM_DUE) && !defined(FEATURE_EEPROM_E24C1024) && defined(FEATURE_MEMORIES)
   #error "In order to use FEATURE_MEMORIES with HARDWARE_ARDUINO_DUE you need FEATURE_EEPROM_E24C1024"
 #endif
 

--- a/keyer_hardware.h
+++ b/keyer_hardware.h
@@ -12,12 +12,25 @@
 // #define HARDWARE_NANOKEYER_REV_B   // https://nanokeyer.wordpress.com/nanokeyer-info/  files: keyer_pin_settings_nanokeyer_rev_b.h, keyer_features_and_options_nanokeyer_rev_b.h, keyer_settings_nanokeyer_rev_b.h
 // #define HARDWARE_NANOKEYER_REV_D   // https://nanokeyer.wordpress.com/nanokeyer-info/  files: keyer_pin_settings_nanokeyer_rev_d.h, keyer_features_and_options_nanokeyer_rev_d.h, keyer_settings_nanokeyer_rev_d.h  
 // #define HARDWARE_OPEN_INTERFACE   // http://remoteqth.com/open-interface.php   files: keyer_pin_settings_open_interface.h, keyer_features_and_options_open_interface.h, keyer_settings_open_interface.h
-// #define HARDWARE_ARDUINO_DUE   
 // #define HARDWARE_TEST
 
+// The models which can compile this sketch without error, has these pre-defined macros. Not tested.
+// ARDUINO_AVR_UNO
+// ARDUINO_SAM_DUE
+// ARDUINO_MAPLE_MINI // http://dan.drown.org/arduino/package_STM32duino_index.json
+// ARDUINO_AVR_PROMICRO // https://raw.githubusercontent.com/sparkfun/Arduino_Boards/master/IDE_Board_Manager/package_sparkfun_index.json
 
 // do not touch anything below this line
 
 #if defined(HARDWARE_NANOKEYER_REV_B) || defined(HARDWARE_NANOKEYER_REV_D) || defined(HARDWARE_OPEN_INTERFACE) || defined(HARDWARE_TEST)
   #define HARDWARE_CUSTOM
 #endif
+
+#if defined(ARDUINO_MAPLE_MINI)
+#define PRIMARY_SERIAL_CLS USBSerial // for &Serial
+#elif defined(ARDUINO_AVR_PROMICRO)
+#define PRIMARY_SERIAL_CLS Serial_ // for &Serial
+#else
+#define PRIMARY_SERIAL_CLS HardwareSerial // for &Serial
+#endif
+#define SECONDARY_SERIAL_CLS HardwareSerial  // for &Serial1


### PR DESCRIPTION
Avoid compile error on Sparkfun ProMicro (atmega32u4) and Maple mini (arm) boards environment.
To know the type of board, pre-defined macros are used.
I think the best way is changing the order of the functions to avoid forward reference error.

I haven't do operation check on those boards still, only for compile.

Thanks in advance.