### PR TITLE
Removed duplicated code about cw_computer_keyboard and some tuning 

### DIFF
--- a/k3ng_keyer/k3ng_keyer.ino
+++ b/k3ng_keyer/k3ng_keyer.ino
@@ -1637,6 +1637,10 @@ void loop()
  
 
 
+/* *************************************************
+**** THIS CODE IS DUPLICATED AND NO NECESSARY  *****
+****       PLEASE CHECK ;) at row 9193         *****   
+****************************************************
 
       #if defined(FEATURE_CW_COMPUTER_KEYBOARD)       
         switch (decode_character){
@@ -1756,7 +1760,7 @@ void loop()
        
 
       #endif //defined(FEATURE_CW_COMPUTER_KEYBOARD) 
-
+*/
       
       // reinitialize everything
       last_transition_time = 0;
@@ -9200,7 +9204,7 @@ void service_paddle_echo()
         no_space = 1;   
         break;
       case 211222: // prosign DO
-        Keyboard.write(KEY_CAPS_LOCK);
+        //Keyboard.write(KEY_CAPS_LOCK); // THIS DON'T WORK ON MAC ;(
         #ifdef OPTION_CW_KEYBOARD_CAPSLOCK_BEEP
           if (cw_keyboard_capslock_on){
             beep();delay(100);


### PR DESCRIPTION

I have commented many row duplicated for cw_computer_keyboard function and paddle_echo.
Please double check before remove these lines, I have tested the feature cw_computer_keyboard and all work well. 

Now Caps Lock (pro sign DO) seem to work on Mac, Windows and Linux (Mac has inverted logic, cannot understand why)
On Windows and Linux the keyer start with inverted caps lock status of Mac OS.