### PR TITLE
Adding Feature for Sidetone Switch

### DIFF
--- a/k3ng_keyer/k3ng_keyer.ino
+++ b/k3ng_keyer/k3ng_keyer.ino
@@ -211,7 +211,10 @@ For help, please consult http://blog.radioartisan.com/support-for-k3ng-projects/
        "......" or more "Backspace"
        "------" or more "Space"
 
-
+  SIDETONE_SWITCH
+       Enabling this feature and an external toggle switch  adds switch control for playing cw sidetone.
+       ST Switch status is displayed in the status command.  This feature will override the software control of the sidetone (\o).
+       
  
 Useful Stuff
     Reset to defaults: squeeze both paddles at power up (good to use if you dorked up the speed and don't have the CLI)
@@ -1350,6 +1353,11 @@ void loop()
     #endif  
 
   }
+
+  #ifdef FEATURE_SIDETONE_SWITCH
+  check_sidetone_switch();
+  #endif //FEATURE_SIDETONE_SWITCH
+
   
 }
 
@@ -3531,6 +3539,11 @@ int ps2_keyboard_get_number_input(byte places,int lower_limit, int upper_limit)
           check_potentiometer();
         }
         #endif
+
+        #ifdef FEATURE_SIDETONE_SWITCH
+        check_sidetone_switch();
+        #endif
+
         #ifdef FEATURE_ROTARY_ENCODER
         check_rotary_encoder();
         #endif //FEATURE_ROTARY_ENCODER
@@ -3729,6 +3742,50 @@ void check_rotary_encoder(){
 }
 #endif //FEATURE_ROTARY_ENCODER
 //-------------------------------------------------------------------------------------------------------
+
+#ifdef FEATURE_SIDETONE_SWITCH
+void check_sidetone_switch()
+{
+	static unsigned long lastcheck = 0 ; 
+
+    if ( millis() - lastcheck < 250 ) return ;
+
+    lastcheck = millis() ;
+
+    int ss_read = sidetone_switch_value();
+
+    if ( (ss_read == HIGH)  && ( (configuration.sidetone_mode == SIDETONE_ON) ||
+                               (configuration.sidetone_mode == SIDETONE_PADDLE_ONLY) )){
+        return ;
+    }
+    if ( (ss_read == LOW)  && configuration.sidetone_mode == SIDETONE_OFF ){
+        return ;
+    }
+    config_dirty = 1;
+    #ifdef FEATURE_SLEEP
+     last_activity_time = millis(); 
+    #endif //FEATURE_SLEEP
+
+    if ( ss_read == HIGH ) {
+        configuration.sidetone_mode = SIDETONE_ON;
+        return ;
+    }
+    if ( ss_read == LOW ){
+        configuration.sidetone_mode = SIDETONE_OFF;
+        return ;
+    }
+}
+
+int sidetone_switch_value()
+{
+    return digitalRead(SIDETONE_SWITCH);
+}
+
+#endif
+
+
+//-------------------------------------------------------------------------------------------------------
+
 
 #ifdef FEATURE_POTENTIOMETER
 void check_potentiometer()
@@ -10649,6 +10706,10 @@ void serial_status(PRIMARY_SERIAL_CLS * port_to_use) {
   port_to_use->print(" ");
   port_to_use->print(configuration.hz_sidetone,DEC);
   port_to_use->println(" hz");
+#ifdef FEATURE_SIDETONE_SWITCH
+  Serial.print("Sidetone Switch: ");
+  Serial.println(sidetone_switch_value() ? F("ON") : F("OFF"));
+#endif // FEATURE_SIDETONE_SWITCH
   port_to_use->print(F("Dah to dit: "));
   port_to_use->println((float(configuration.dah_to_dit_ratio)/100));
   port_to_use->print(F("Weighting: "));
@@ -12210,6 +12271,10 @@ void initialize_pins() {
       digitalWrite(keyer_awake,KEYER_AWAKE_PIN_AWAKE_STATE);
     }
   #endif //FEATURE_SLEEP
+
+  #ifdef FEATURE_SIDETONE_SWITCH
+  pinMode(SIDETONE_SWITCH,INPUT);
+  #endif //FEATURE_SIDETONE_SWITCH
 
   
 }

--- a/k3ng_keyer/keyer_features_and_options.h
+++ b/k3ng_keyer/keyer_features_and_options.h
@@ -10,6 +10,7 @@
 // #define FEATURE_BEACON
 // #define FEATURE_CALLSIGN_RECEIVE_PRACTICE
 // #define FEATURE_POTENTIOMETER         // do not enable unless you have a potentiometer connected, otherwise noise will falsely trigger wpm changes
+// #define FEATURE_SIDETONE_SWITCH   // adds switch control for the sidetone output. requires an external toggle switch (assigned to an arduino pin - see keyer_pin_settings.h). 
 // #define FEATURE_SERIAL_HELP
 // #define FEATURE_HELL
 // #define FEATURE_PS2_KEYBOARD        // Use a PS2 keyboard to send code - Change keyboard layout (non-US) in K3NG_PS2Keyboard.h.  Additional options below.

--- a/k3ng_keyer/keyer_pin_settings.h
+++ b/k3ng_keyer/keyer_pin_settings.h
@@ -26,6 +26,17 @@
   #define command_mode_active_led 0
 #endif //FEATURE_COMMAND_BUTTONS
 
+/*
+FEATURE_SIDETONE_SWITCH
+  Enabling this feature and an external toggle switch  adds switch control for playing cw sidetone.
+  ST Switch status is displayed in the status command.  This feature will override the software control of the sidetone (\o).
+  Arduino pin is assigned by SIDETONE_SWITCH 
+*/
+
+#ifdef FEATURE_SIDETONE_SWITCH
+#define SIDETONE_SWITCH 8
+#endif //FEATURE_SIDETONE_SWITCH
+
 
 //lcd pins
 #ifdef FEATURE_LCD_4BIT


### PR DESCRIPTION
The contribution adds a sidetone switch for the k3ng keyer.
Enabling this feature and an external toggle switch adds switch control
for playing cw sidetone, which I found to be a useful feature for the keyer.
The feature will override software control of
sidetone (\o). Switch status is displayed in the status command (\s) (adds the line: "Sidetone Switch: ON"). This feature is enabled by a DEFINE statement (FEATURE_SIDETONE_SWITCH), and should not cause any compile issue if left undefined. 