### PR TITLE
Allow encoder to change command mode keyer speed

### DIFF
--- a/k3ng_keyer/k3ng_keyer.ino
+++ b/k3ng_keyer/k3ng_keyer.ino
@@ -4769,7 +4769,11 @@ void check_rotary_encoder(){
   int step = chk_rotary_encoder();
 
   if (step != 0) {
-    speed_change(step);
+    if (keyer_machine_mode == KEYER_COMMAND_MODE) {
+      speed_change_command_mode(step);
+    } else {
+      speed_change(step);
+    }
      
     // Start of Winkey Speed change mod for Rotary Encoder -- VE2EVN
     #ifdef FEATURE_WINKEY_EMULATION


### PR DESCRIPTION
This simple change allows the command mode keyer speed to be adjusted by the rotary encoder.  It is very helpful for changing the keyer speed while using practice modes.