### PR TITLE
Fix case sensitive include

### DIFF
--- a/k3ng_keyer/src/buttonarray/buttonarray.cpp
+++ b/k3ng_keyer/src/buttonarray/buttonarray.cpp
@@ -1,4 +1,4 @@
-#include "arduino.h"
+#include "Arduino.h"
 #include "buttonarray.h"
 
 Button::InitLimits(uint8_t step){

--- a/src/buttonarray/buttonarray.cpp
+++ b/src/buttonarray/buttonarray.cpp
@@ -1,4 +1,4 @@
-#include "arduino.h"
+#include "Arduino.h"
 #include "buttonarray.h"
 
 Button::InitLimits(uint8_t step){


### PR DESCRIPTION
Under Linux the compilation fails with the following error:

 sketch/src/buttonarray/buttonarray.cpp:1:10: fatal error: arduino.h: No such file or directory
 #include "arduino.h"
          ^~~~~~~~~~~

In this PR I'm also changing the other file for consistency, even if it doesn't seem to be compiled at this moment.

Daniele, IU5HKX