### PR TITLE
Custom startup text

### DIFF
--- a/k3ng_keyer/k3ng_keyer.ino
+++ b/k3ng_keyer/k3ng_keyer.ino
@@ -17151,7 +17151,15 @@ void initialize_display(){
     if (LCD_COLUMNS < 9){
       lcd_center_print_timed("K3NGKeyr",0,4000);
     } else {
-      lcd_center_print_timed("K3NG Keyer",0,4000);
+      #ifdef OPTION_PERSONALIZED_STARTUP_SCREEN
+        if (LCD_ROWS = 2) {
+	  #ifdef OPTION_DO_NOT_SAY_HI                                 // if we wish to display the custom field on the second line, we can't say 'hi'
+	    lcd_center_print_timed(custom_startup_field, 1, 4000);    // display the custom field on the second line of the display, maximum field length is the number of columns
+          #endif                                                      // OPTION_DO_NOT_SAY_HI
+	}  
+	else if (LCD_ROWS > 2) lcd_center_print_timed(custom_startup_field, 2, 4000);      // display the custom field on the third line of the display, maximum field length is the number of columns
+      #endif                                                          // OPTION_PERSONALIZED_STARTUP_SCREEN
+      if (LCD_ROWS > 3) lcd_center_print_timed("V: " + CODE_VERSION, 3, 4000);             // display the code version on the fourth line of the display
     }
   #endif //FEATURE_DISPLAY
 

--- a/k3ng_keyer/k3ng_keyer.ino
+++ b/k3ng_keyer/k3ng_keyer.ino
@@ -17152,14 +17152,14 @@ void initialize_display(){
       lcd_center_print_timed("K3NGKeyr",0,4000);
     } else {
       #ifdef OPTION_PERSONALIZED_STARTUP_SCREEN
-        if (LCD_ROWS = 2) {
+        if (LCD_ROWS == 2) {
 	  #ifdef OPTION_DO_NOT_SAY_HI                                 // if we wish to display the custom field on the second line, we can't say 'hi'
 	    lcd_center_print_timed(custom_startup_field, 1, 4000);    // display the custom field on the second line of the display, maximum field length is the number of columns
           #endif                                                      // OPTION_DO_NOT_SAY_HI
 	}  
 	else if (LCD_ROWS > 2) lcd_center_print_timed(custom_startup_field, 2, 4000);      // display the custom field on the third line of the display, maximum field length is the number of columns
       #endif                                                          // OPTION_PERSONALIZED_STARTUP_SCREEN
-      if (LCD_ROWS > 3) lcd_center_print_timed("V: " + CODE_VERSION, 3, 4000);             // display the code version on the fourth line of the display
+      if (LCD_ROWS > 3) lcd_center_print_timed("V: " + String(CODE_VERSION), 3, 4000);             // display the code version on the fourth line of the display
     }
   #endif //FEATURE_DISPLAY
 

--- a/k3ng_keyer/keyer_features_and_options.h
+++ b/k3ng_keyer/keyer_features_and_options.h
@@ -113,5 +113,6 @@
 
 // #define OPTION_EXCLUDE_MILL_MODE
 
-//#define OPTION_ENABLE_SERIAL_PORT_CHECKING_WHILE_SENDING_CW_MAY_CAUSE_PROBLEMS
+// #define OPTION_ENABLE_SERIAL_PORT_CHECKING_WHILE_SENDING_CW_MAY_CAUSE_PROBLEMS
+// #define OPTION_PERSONALIZED_STARTUP_SCREEN        // displays a user defined string of characters on the second or fourth row of the screen during startup. 1602 display requires OPTION_DO_NOT_SAY_HI
 

--- a/k3ng_keyer/keyer_settings.h
+++ b/k3ng_keyer/keyer_settings.h
@@ -274,3 +274,5 @@
 
 #define sidetone_volume_low_limit 10
 #define sidetone_volume_high_limit 500
+
+#define custom_startup_field " "   // an example could be callsign and name, eg. "AB1XYZ Bob", (or "Worlds best operator" which requires a 20 column display), string length shouldo be no more than the number of columns on the display


### PR DESCRIPTION
The purpose of the change is to allow the end user to define a custom string that will be displayed briefly (for the default 4 seconds) on the startup screen as the keyer is powered up or reset.
The custom string is defined in keyer_settings.h
The option OPTION_PERSONALIZED_STARTUP_SCREEN is in keyer_features_and_options.h
The code changes in the main sketch check if the display is specified to have just two lines. If so then saying 'hi' takes precedence on the second line and we do not display the custom string, so if we are not saying 'hi' then we can display the custom text on the second line.
If the display is specified to have three lines then we will display the custom text on the third line (we can still say 'hi' on the second line) and if we have four or more lines then we also display the code version on the fourth line.
No string length checking is performed (although it would be easy to add in) and the onus is on the end user to take care that the string length does not exceed the number of columns on the display.
Different displays behave differently with oversized strings. Some will scroll right and the leading characters get dropped off the left hand side, other displays simply will not display any more characters than the number of columns that the display has and excess characters don't appear.