### PR TITLE
Fk 11 support

### DIFF
--- a/k3ng_keyer/k3ng_keyer.ino
+++ b/k3ng_keyer/k3ng_keyer.ino
@@ -1173,6 +1173,8 @@ Recent Update History
   #include "keyer_features_and_options_tinykeyer.h"
 #elif defined(HARDWARE_FK_10)
   #include "keyer_features_and_options_fk_10.h"  
+#elif defined(HARDWARE_FK_11)
+  #include "keyer_features_and_options_fk_11.h"
 #elif defined(HARDWARE_MAPLE_MINI)//sp5iou 20180328
   #include "keyer_features_and_options_maple_mini.h"
 #elif defined(HARDWARE_GENERIC_STM32F103C)//sp5iou 20180329
@@ -1233,6 +1235,9 @@ Recent Update History
 #elif defined(HARDWARE_FK_10)
   #include "keyer_pin_settings_fk_10.h"
   #include "keyer_settings_fk_10.h"
+#elif defined(HARDWARE_FK_11)
+  #include "keyer_pin_settings_fk_11.h"
+  #include "keyer_settings_fk_11.h"
 #elif defined(HARDWARE_MAPLE_MINI)
   #include "keyer_pin_settings_maple_mini.h"
   #include "keyer_settings_maple_mini.h"

--- a/k3ng_keyer/keyer_features_and_options_fk_11.h
+++ b/k3ng_keyer/keyer_features_and_options_fk_11.h
@@ -1,0 +1,118 @@
+// compile time features and options - comment or uncomment to add or delete features
+// FEATURES add more bytes to the compiled binary, OPTIONS change code behavior
+
+// Funtronics FK-11
+
+#define FEATURE_COMMAND_BUTTONS
+#define FEATURE_COMMAND_LINE_INTERFACE  // Command Line Interface functionality
+#define FEATURE_MEMORIES             // on the Arduino Due, you must have FEATURE_EEPROM_E24C1024 and E24C1024 EEPROM hardware in order to compile this
+#define FEATURE_MEMORY_MACROS
+#define FEATURE_WINKEY_EMULATION    // disabling Automatic Software Reset is highly recommended (see documentation)
+#define FEATURE_BEACON
+#define FEATURE_TRAINING_COMMAND_LINE_INTERFACE
+// #define FEATURE_POTENTIOMETER         // do not enable unless you have a potentiometer connected, otherwise noise will falsely trigger wpm changes
+// #define FEATURE_SIDETONE_SWITCH   // adds switch control for the sidetone output. requires an external toggle switch (assigned to an arduino pin - see keyer_pin_settings.h). 
+#define FEATURE_SERIAL_HELP
+#define FEATURE_HELL
+// #define FEATURE_PS2_KEYBOARD        // Use a PS2 keyboard to send code - Change keyboard layout (non-US) in K3NG_PS2Keyboard.h.  Additional options below.
+#define FEATURE_USB_KEYBOARD          // Use a USB keyboard to send code - Uncomment three lines in k3ng_keyer.ino (search for note_usb_uncomment_lines)
+// #define FEATURE_CW_COMPUTER_KEYBOARD  // Have an Arduino Due or Leonardo act as a USB HID (Human Interface Device) keyboard and use the paddle to "type" characters on the computer -- uncomment this line in ino file: #include <Keyboard.h>
+#define FEATURE_DEAD_OP_WATCHDOG
+#define FEATURE_AUTOSPACE
+#define FEATURE_FARNSWORTH
+// #define FEATURE_DL2SBA_BANKSWITCH       // Switch memory banks feature as described here: http://dl2sba.com/index.php?option=com_content&view=article&id=131:nanokeyer&catid=15:shack&Itemid=27#english
+// #define FEATURE_LCD_4BIT                // classic LCD disidefplay using 4 I/O lines
+// #define FEATURE_LCD_8BIT                // classic LCD display using 8 I/O lines
+// #define FEATURE_LCD_ADAFRUIT_I2C          // Adafruit I2C LCD display using MCP23017 at addr 0x20
+// #define FEATURE_LCD_ADAFRUIT_BACKPACK    // Adafruit I2C LCD Backup using MCP23008 (courtesy Josiah Ritchie, KE0BLL)
+// #define FEATURE_LCD_YDv1                // YourDuino I2C LCD display with old LCM 1602 V1 ic
+// #define FEATURE_LCD1602_N07DH      // http://linksprite.com/wiki/index.php5?title=16_X_2_LCD_Keypad_Shield_for_Arduino
+// #define FEATURE_LCD_SAINSMART_I2C
+#define FEATURE_LCD_FABO_PCF8574  // https://github.com/FaBoPlatform/FaBoLCD-PCF8574-Library
+// #define FEATURE_LCD_MATHERTEL_PCF8574 // https://github.com/mathertel/LiquidCrystal_PCF8574
+// #define FEATURE_LCD_HD44780
+#define FEATURE_CW_DECODER
+// #define FEATURE_SLEEP                   // go to sleep after x minutes to conserve battery power (not compatible with Arduino DUE, may have mixed results with Mega and Mega ADK)
+#define FEATURE_ROTARY_ENCODER          // rotary encoder speed control
+#define FEATURE_CMOS_SUPER_KEYER_IAMBIC_B_TIMING
+#define FEATURE_USB_MOUSE               // Uncomment three lines in k3ng_keyer.ino (search for note_usb_uncomment_lines)
+// #define FEATURE_CAPACITIVE_PADDLE_PINS  // remove the bypass capacitors on the paddle_left and paddle_right lines when using capactive paddles
+// #define FEATURE_LED_RING                // Mayhew Labs Led Ring support
+#define FEATURE_ALPHABET_SEND_PRACTICE  // enables command mode S command - created by Ryan, KC2ZWM
+// #define FEATURE_COMMAND_MODE_PROGRESSIVE_5_CHAR_ECHO_PRACTICE // enables command mode U
+// #define FEATURE_PTT_INTERLOCK 
+// #define FEATURE_QLF
+// #define FEATURE_EEPROM_E24C1024
+// #define FEATURE_STRAIGHT_KEY
+// #define FEATURE_DYNAMIC_DAH_TO_DIT_RATIO
+// #define FEATURE_PADDLE_ECHO
+// #define FEATURE_STRAIGHT_KEY_ECHO
+// #define FEATURE_AMERICAN_MORSE
+// #define FEATURE_4x4_KEYPAD          // code contributed by Jack, W0XR - documentation: https://github.com/k3ng/k3ng_cw_keyer/wiki/380-Feature:-Keypad
+// #define FEATURE_3x4_KEYPAD          // code contributed by Jack, W0XR - documentation: https://github.com/k3ng/k3ng_cw_keyer/wiki/380-Feature:-Keypad
+// #define FEATURE_SEQUENCER
+
+#define FEATURE_COMMAND_LINE_INTERFACE_ON_SECONDARY_PORT     // Activate the Command Line interface on the secondary serial port
+#define OPTION_PRIMARY_SERIAL_PORT_DEFAULT_WINKEY_EMULATION  // Use when activating both FEATURE_WINKEY_EMULATION and FEATURE_COMMAND_LINE_INTERFACE 
+                                                             //    simultaneously.  This will make Winkey emulation be the default at boot up; 
+                                                             //    hold command button down at boot up to activate CLI mode
+
+// #define OPTION_SUPPRESS_SERIAL_BOOT_MSG
+#define OPTION_INCLUDE_PTT_TAIL_FOR_MANUAL_SENDING
+#define OPTION_EXCLUDE_PTT_HANG_TIME_FOR_MANUAL_SENDING
+// #define OPTION_WINKEY_DISCARD_BYTES_AT_STARTUP     // if ASR is not disabled, you may need this to discard errant serial port bytes at startup
+// #define OPTION_WINKEY_STRICT_EEPROM_WRITES_MAY_WEAR_OUT_EEPROM // with this activated the unit will write non-volatile settings to EEPROM when set by Winkey commands
+// #define OPTION_WINKEY_SEND_WORDSPACE_AT_END_OF_BUFFER
+#define OPTION_WINKEY_STRICT_HOST_OPEN               // require an admin host open Winkey command before doing any other commands
+#define OPTION_WINKEY_2_SUPPORT                      // comment out to revert to Winkey version 1 emulation
+#define OPTION_WINKEY_INTERRUPTS_MEMORY_REPEAT
+//#define OPTION_WINKEY_UCXLOG_9600_BAUD              // use this only with UCXLog configured for Winkey 9600 baud mode
+#define OPTION_WINKEY_2_HOST_CLOSE_NO_SERIAL_PORT_RESET  // (Required for Win-Test to function)
+// #define OPTION_WINKEY_FREQUENT_STATUS_REPORT         // activate this to make Winkey emulation play better with RUMlog and RUMped
+#define OPTION_WINKEY_IGNORE_LOWERCASE               // Enable for typical K1EL Winkeyer behavior (use for SkookumLogger version 1.10.14 and prior to workaround "r" bug)
+// #define OPTION_WINKEY_BLINK_PTT_ON_HOST_OPEN
+// #define OPTION_WINKEY_SEND_VERSION_ON_HOST_CLOSE
+// #define OPTION_REVERSE_BUTTON_ORDER                // This is mainly for the DJ0MY NanoKeyer http://nanokeyer.wordpress.com/
+#define OPTION_PROG_MEM_TRIM_TRAILING_SPACES         // trim trailing spaces from memory when programming in command mode
+#define OPTION_DIT_PADDLE_NO_SEND_ON_MEM_RPT         // this makes dit paddle memory interruption a little smoother
+#define OPTION_MORE_DISPLAY_MSGS                     // additional optional display messages - comment out to save memory
+#define OPTION_WATCHDOG_TIMER                        // this enables a four second ATmega48/88/168/328 watchdog timer; use for unattended/remote operation only
+#define OPTION_MOUSE_MOVEMENT_PADDLE               // experimental (just fooling around) - mouse movement will act like a paddle
+// #define OPTION_NON_ENGLISH_EXTENSIONS  // add support for additional CW characters (i.e. À, Å, Þ, etc.)
+// #define OPTION_DISPLAY_NON_ENGLISH_EXTENSIONS  // LCD display suport for non-English (NO/DK/DE) characters - Courtesy of OZ1JHM
+// #define OPTION_UNKNOWN_CHARACTER_ERROR_TONE
+// #define OPTION_DO_NOT_SAY_HI
+// #define OPTION_PS2_NON_ENGLISH_CHAR_LCD_DISPLAY_SUPPORT // makes some non-English characters from the PS2 keyboard display correctly in the LCD display (donated by Marcin sp5iou)
+// #define OPTION_PS2_KEYBOARD_RESET // reset the PS2 keyboard upon startup with 0xFF (contributed by Bill, W9BEL)
+// #define OPTION_SAVE_MEMORY_NANOKEYER
+// #define OPTION_CW_KEYBOARD_CAPSLOCK_BEEP
+// #define OPTION_CW_KEYBOARD_ITALIAN
+// #define OPTION_CW_KEYBOARD_GERMAN
+#define OPTION_CW_DECODER_GOERTZEL_AUDIO_DETECTOR
+// #define OPTION_INVERT_PADDLE_PIN_LOGIC
+#define OPTION_ADVANCED_SPEED_DISPLAY //enables "nerd" speed visualization on display: wpm, cpm (char per min), duration of dit and dah in milliseconds and ratio (contributed by Giorgio, IZ2XBZ)
+#define OPTION_PROSIGN_SUPPORT    // additional prosign support for paddle and straight key echo on display, CLI, and in memory storage
+// #define OPTION_RUSSIAN_LANGUAGE_SEND_CLI // Russian language CLI sending support (contributed by Павел Бирюков, UA1AQC)
+#define OPTION_DO_NOT_SEND_UNKNOWN_CHAR_QUESTION
+// #define OPTION_CMOS_SUPER_KEYER_IAMBIC_B_TIMING_ON_BY_DEFAULT
+// #define OPTION_SIDETONE_DIGITAL_OUTPUT_NO_SQUARE_WAVE
+// #define FEATURE_SD_CARD_SUPPORT
+// #define FEATURE_SO2R_BASE           // SO2R Box base protocol extensions
+// #define FEATURE_SO2R_SWITCHES       // SO2R Box TX and RX switches
+// #define FEATURE_SO2R_ANTENNA        // SO2R Box antenna selection (not fully implemented)
+
+#define OPTION_DIRECT_PADDLE_PIN_READS_MEGA   // only works with Mega and pins 2 and 5 - minor performance increase
+// #define OPTION_DIRECT_PADDLE_PIN_READS_UNO    // Unos or Nanos pins 2 and 5 - do not enable on a nanoKeyer, it uses different pins
+
+// #define OPTION_WORDSWORTH_CZECH
+// #define OPTION_WORDSWORTH_DEUTSCH
+// #define OPTION_WORDSWORTH_NORSK
+
+#define OPTION_EXCLUDE_EXTENDED_CLI_COMMANDS
+
+// #define OPTION_DFROBOT_LCD_COMMAND_BUTTONS
+
+// #define OPTION_EXCLUDE_MILL_MODE
+
+//#define OPTION_ENABLE_SERIAL_PORT_CHECKING_WHILE_SENDING_CW_MAY_CAUSE_PROBLEMS
+

--- a/k3ng_keyer/keyer_hardware.h
+++ b/k3ng_keyer/keyer_hardware.h
@@ -65,7 +65,7 @@
 
       Note: in order to get the FK-11 USB Host port working correctly you will need to:
       - Uncomment three lines in in file: k3ng_keyer.ino below 'note_usb_uncomment_lines'.
-      - Add line to file k3ng_cw_keyer/libraries/USB_Host_Shield_Library_2.0/settings.h: #define BOARD_MEGA_ADK
+      - Add line to file k3ng_cw_keyer/libraries/USB_Host_Shield_Library_2.0/settings.h, below 'Manual board activation': #define BOARD_MEGA_ADK
 */
 
 

--- a/k3ng_keyer/keyer_hardware.h
+++ b/k3ng_keyer/keyer_hardware.h
@@ -14,6 +14,7 @@
 // #define HARDWARE_OPEN_INTERFACE   // http://remoteqth.com/open-interface.php   edit these files: keyer_pin_settings_open_interface.h, keyer_features_and_options_open_interface.h, keyer_settings_open_interface.h   
 // #define HARDWARE_TINYKEYER   // http://www.ok1rr.com/index.php/technical-topics/122-the-tinykeyer   edit these files: keyer_pin_settings_tinykeyer.h, keyer_features_and_options_tinykeyer.h, keyer_settings_tinykeyer.h
 // #define HARDWARE_FK_10  // Funtronics K3NG Keyer FK-10  - See notes below!!!  http://www.elekitsorparts.com/product/funtronics-k3ng-keyer-fk-10-99-winkey-emulation/   files: keyer_pin_settings_fk_10.h, keyer_features_and_options_fk_10.h, keyer_settings_fk_10.h
+#define HARDWARE_FK_11 // Funtronics K3NG Keyer FK-11 - See notes below! https://www.elekitsorparts.com/?product=funtronics-k3ng-keyer-with-99-winkey-emulation files: keyer_pin_settings_fk_11.h, keyer_features_and_options_fk_11.h, keyer_settings_fk_11.h
 // #define HARDWARE_MAPLE_MINI  // edit these files: keyer_pin_settings_maple_mini.h, keyer_settings_maple_mini.h, keyer_features_and_options_maple_mini.h
 // #define HARDWARE_GENERIC_STM32F103C  // edit these files: keyer_pin_settings_generic_STM32F103C.h, keyer_settings_generic_STM32F103C.h, keyer_features_and_options_generic_STM32F103C.h //sp5iou 20180329
 // #define HARDWARE_MORTTY  // edit these files: keyer_pin_settings_mortty.h, keyer_settings_mortty.h, keyer_features_and_options_mortty.h
@@ -57,7 +58,14 @@
              typedef MAX3421e<P53, P9> MAX3421E; // Official Arduinos (UNO, Duemilanove, Mega, 2560, Leonardo, Due etc.) or Teensy 2.0 and 3.0
            #endif
 
+    Funtronics FK-11 Programming Notes
 
+      Programming the unit is accomplished by selecting "Mega2560" as the target processor and uploading to the rear USB port with the front
+      switch set to the Arduino position.
+
+      Note: in order to get the FK-11 USB Host port working correctly you will need to:
+      - Uncomment three lines in in file: k3ng_keyer.ino below 'note_usb_uncomment_lines'.
+      - Add line to file k3ng_cw_keyer/libraries/USB_Host_Shield_Library_2.0/settings.h: #define BOARD_MEGA_ADK
 */
 
 

--- a/k3ng_keyer/keyer_hardware.h
+++ b/k3ng_keyer/keyer_hardware.h
@@ -60,12 +60,18 @@
 
     Funtronics FK-11 Programming Notes
 
-      Programming the unit is accomplished by selecting "Mega2560" as the target processor and uploading to the rear USB port with the front
-      switch set to the Arduino position.
+      Programming the unit is accomplished by selecting "Arduino Mega 2560" as the target processor and uploading to the rear USB port with the
+      front switch set to the Arduino position.
 
+      Note: in order to get the FK-11 display working correctly you will need to:
+      - Install FaBo_212_LCD_PCF8574 library
+      - Set the slave address to 0x27 in FaBo_212_LCD_PCF8574/src/FaBoLCD_PCF8574.h
+        #define PCF8574_SLAVE_ADDRESS 0x27
+      
       Note: in order to get the FK-11 USB Host port working correctly you will need to:
       - Uncomment three lines in in file: k3ng_keyer.ino below 'note_usb_uncomment_lines'.
-      - Add line to file k3ng_cw_keyer/libraries/USB_Host_Shield_Library_2.0/settings.h, below 'Manual board activation': #define BOARD_MEGA_ADK
+      - Add line to file k3ng_cw_keyer/libraries/USB_Host_Shield_Library_2.0/settings.h, below 'Manual board activation':
+        #define BOARD_MEGA_ADK
 */
 
 

--- a/k3ng_keyer/keyer_hardware.h
+++ b/k3ng_keyer/keyer_hardware.h
@@ -70,7 +70,7 @@
       
       Note: in order to get the FK-11 USB Host port working correctly you will need to:
       - Uncomment three lines in in file: k3ng_keyer.ino below 'note_usb_uncomment_lines'.
-      - Add line to file k3ng_cw_keyer/libraries/USB_Host_Shield_Library_2.0/settings.h, below 'Manual board activation':
+      - Add line to file k3ng_cw_keyer/libraries/USB_Host_Shield/settings.h, below 'Manual board activation':
         #define BOARD_MEGA_ADK
 */
 

--- a/k3ng_keyer/keyer_pin_settings_fk_11.h
+++ b/k3ng_keyer/keyer_pin_settings_fk_11.h
@@ -1,0 +1,164 @@
+// Funtronics FK-11
+
+/* Pins - you must review these and configure ! */
+#ifndef keyer_pin_settings_h
+#define keyer_pin_settings_h
+
+#define paddle_left 2
+#define paddle_right 5
+#define tx_key_line_1 39        // (high = key down/tx on)
+#define tx_key_line_2 0 
+#define tx_key_line_3 0
+#define tx_key_line_4 0
+#define tx_key_line_5 0
+#define tx_key_line_6 0
+#define sidetone_line 3         // connect a speaker for sidetone
+#define potentiometer A0        // Speed potentiometer (0 to 5 V) Use pot from 1k to 10k
+#define ptt_tx_1 40             // PTT ("push to talk") lines
+#define ptt_tx_2 0              //   Can be used for keying fox transmitter, T/R switch, or keying slow boatanchors
+#define ptt_tx_3 0              //   These are optional - set to 0 if unused
+#define ptt_tx_4 0
+#define ptt_tx_5 0
+#define ptt_tx_6 0
+#define tx_key_dit 0            // if defined, goes active for dit (any transmitter) - customized with tx_key_dit_and_dah_pins_active_state and tx_key_dit_and_dah_pins_inactive_state
+#define tx_key_dah 0            // if defined, goes active for dah (any transmitter) - customized with tx_key_dit_and_dah_pins_active_state and tx_key_dit_and_dah_pins_inactive_state
+
+#define potentiometer_enable_pin 0  // if defined, the potentiometer will be enabled only when this pin is held low; set to 0 to ignore this pin
+
+#ifdef FEATURE_COMMAND_BUTTONS
+  #define analog_buttons_pin A2
+  #define command_mode_active_led 0
+#endif //FEATURE_COMMAND_BUTTONS
+
+/*
+FEATURE_SIDETONE_SWITCH
+  Enabling this feature and an external toggle switch  adds switch control for playing cw sidetone.
+  ST Switch status is displayed in the status command.  This feature will override the software control of the sidetone (\o).
+  Arduino pin is assigned by SIDETONE_SWITCH 
+*/
+
+#ifdef FEATURE_SIDETONE_SWITCH
+  #define SIDETONE_SWITCH 8
+#endif //FEATURE_SIDETONE_SWITCH
+
+
+//lcd pins
+#if defined(FEATURE_LCD_4BIT) || defined(FEATURE_LCD_8BIT)
+  #define lcd_rs A2
+  #define lcd_enable 10  // pin 10 is used by Ethernet shield and will conflict with that
+  #define lcd_d4 6
+  #define lcd_d5 7
+  #define lcd_d6 8
+  #define lcd_d7 9
+#endif //FEATURE_LCD_4BIT || defined(FEATURE_LCD_8BIT)
+
+#if defined(FEATURE_LCD_8BIT) // addition four data lines for 8 bit LCD control
+  #define lcd_d0 20
+  #define lcd_d1 21
+  #define lcd_d2 22
+  #define lcd_d3 23
+#endif //FEATURE_LCD_4BIT || defined(FEATURE_LCD_8BIT)
+
+#ifdef FEATURE_LCD1602_N07DH
+  #define lcd_rs 8
+  #define lcd_enable 9
+  #define lcd_d4 4
+  #define lcd_d5 5
+  #define lcd_d6 6
+  #define lcd_d7 7
+#endif //FEATURE_LCD1602_N07DH
+
+//ps2 keyboard pins
+#ifdef FEATURE_PS2_KEYBOARD
+  #define ps2_keyboard_data A3
+  #define ps2_keyboard_clock 3    // this must be on an interrupt capable pin!
+#endif //FEATURE_PS2_KEYBOARD
+
+// rotary encoder pins and options - rotary encoder code from Jim Balls M0CKE
+#ifdef FEATURE_ROTARY_ENCODER
+  #define OPTION_ENCODER_HALF_STEP_MODE     // Half-step mode?
+  #define rotary_pin1 43                     // CW Encoder Pin
+  #define rotary_pin2 42                     // CCW Encoder Pin
+  #define OPTION_ENCODER_ENABLE_PULLUPS     // define to enable weak pullups.
+#endif //FEATURE_ROTARY_ENCODER
+
+#ifdef FEATURE_LED_RING
+  #define led_ring_sdi    A10 //2    //Data
+  #define led_ring_clk    A9 //3    //Clock
+  #define led_ring_le     A8 //4    //Latch
+#endif //FEATURE_LED_RING
+
+#ifdef FEATURE_ALPHABET_SEND_PRACTICE
+  #define correct_answer_led 0
+  #define wrong_answer_led 0
+#endif //FEATURE_ALPHABET_SEND_PRACTICE
+
+#ifdef FEATURE_PTT_INTERLOCK
+  #define ptt_interlock 0  // this pin disables PTT and TX KEY
+#endif //FEATURE_PTT_INTERLOCK
+
+#ifdef FEATURE_STRAIGHT_KEY
+  #define pin_straight_key 52
+#endif //FEATURE_STRAIGHT_KEY
+
+#ifdef FEATURE_CW_DECODER
+  #define cw_decoder_pin A4//A11 //A5 //A3
+  #ifdef OPTION_CW_DECODER_GOERTZEL_AUDIO_DETECTOR
+    #define cw_decoder_audio_input_pin A4 // this must be an analog pin!
+  #endif //OPTION_CW_DECODER_GOERTZEL_AUDIO_DETECTOR
+  #define cw_decoder_indicator 4
+#endif //FEATURE_CW_DECODER
+
+
+#if defined(FEATURE_COMPETITION_COMPRESSION_DETECTION)
+  #define compression_detection_pin 13
+#endif //FEATURE_COMPETITION_COMPRESSION_DETECTION
+
+#if defined(FEATURE_SLEEP)
+  #define keyer_awake 0
+#endif
+
+#if defined(FEATURE_CAPACITIVE_PADDLE_PINS)
+  #define capactive_paddle_pin_inhibit_pin 0     // if this pin is defined and is set high, the capacitive paddle pins will switch to normal (non-capacitive) sensing mode
+#endif
+
+#ifdef FEATURE_4x4_KEYPAD
+  #define Row3 33
+  #define Row2 32
+  #define Row1 31
+  #define Row0 30
+  #define Col3 37
+  #define Col2 36
+  #define Col1 35
+  #define Col0 34
+#endif
+
+#ifdef FEATURE_3x4_KEYPAD
+  #define Row3 33
+  #define Row2 32
+  #define Row1 31
+  #define Row0 30
+  #define Col2 36
+  #define Col1 35
+  #define Col0 34
+#endif
+
+#ifdef FEATURE_SEQUENCER
+  #define sequencer_1_pin 0
+  #define sequencer_2_pin 0
+  #define sequencer_3_pin 0
+  #define sequencer_4_pin 0
+  #define sequencer_5_pin 0
+#endif //FEATURE_SEQUENCER
+
+#define ptt_input_pin 0
+
+#define tx_inhibit_pin 0
+#define tx_pause_pin 0   
+
+#else
+
+  #error "Multiple pin_settings.h files included somehow..."
+
+#endif //keyer_pin_settings_h
+

--- a/k3ng_keyer/keyer_settings_fk_11.h
+++ b/k3ng_keyer/keyer_settings_fk_11.h
@@ -1,0 +1,278 @@
+// Funtronics FK-11
+
+// Initial and hardcoded settings
+#define initial_speed_wpm 26             // "factory default" keyer speed setting
+#define initial_command_mode_speed_wpm 20 // "factory default" command mode speed setting 
+#define initial_sidetone_freq 600        // "factory default" sidetone frequency setting
+#define sidetone_hz_limit_low 299
+#define sidetone_hz_limit_high 2001
+#define hz_high_beep 1500                // frequency in hertz of high beep
+#define hz_low_beep 400                  // frequency in hertz of low beep
+#define initial_dah_to_dit_ratio 300     // 300 = 3 / normal 3:1 ratio
+#define initial_ptt_lead_time_tx1 0         // PTT lead time in mS
+#define initial_ptt_tail_time_tx1 10         // PTT tail time in mS
+#define initial_ptt_lead_time_tx2 0         // PTT lead time in mS
+#define initial_ptt_tail_time_tx2 10         // PTT tail time in mS
+#define initial_ptt_lead_time_tx3 0         // PTT lead time in mS
+#define initial_ptt_tail_time_tx3 10         // PTT tail time in mS
+#define initial_ptt_lead_time_tx4 0         // PTT lead time in mS
+#define initial_ptt_tail_time_tx4 10         // PTT tail time in mS
+#define initial_ptt_lead_time_tx5 0         // PTT lead time in mS
+#define initial_ptt_tail_time_tx5 10         // PTT tail time in mS
+#define initial_ptt_lead_time_tx6 0         // PTT lead time in mS
+#define initial_ptt_tail_time_tx6 10         // PTT tail time in mS
+#define initial_qrss_dit_length 1        // QRSS dit length in seconds
+#define initial_pot_wpm_low_value 13     // Potentiometer WPM fully CCW
+#define initial_pot_wpm_high_value 35    // Potentiometer WPM fully CW
+#define wpm_limit_low 5
+#define wpm_limit_high 60
+#define potentiometer_change_threshold 0.9 // don't change the keyer speed until pot wpm has changed more than this
+#define send_buffer_size 150
+#define default_length_letterspace 3
+#define default_length_wordspace 7
+#define default_keying_compensation 0    // number of milliseconds to extend all dits and dahs - for QSK on boatanchors
+#define default_first_extension_time 0   // number of milliseconds to extend first sent dit or dah
+#define default_pot_full_scale_reading 1023
+#define default_weighting 50             // 50 = weighting factor of 1 (normal)
+#define default_ptt_hang_time_wordspace_units 0.0
+#define memory_area_end 1023             // the eeprom location where memory space ends
+#define winkey_c0_wait_time 1            // the number of milliseconds to wait to send 0xc0 byte after send buffer has been sent
+#define winkey_command_timeout_ms 5000
+#define winkey_discard_bytes_startup 3   // this is used if OPTION_WINKEY_DISCARD_BYTES_AT_STARTUP is enabled above
+#define winkey_xoff_threshold 20         // the number of chars in the buffer when we begin sending XOFFs
+#define winkey_xon_threshold 10          // the number of chars in the buffer below which we deactivate XOFF
+#define default_memory_repeat_time 3000  // time in milliseconds
+#define LCD_COLUMNS 16
+#define LCD_ROWS 2
+#define lcd_i2c_address_mathertel_PCF8574 0x27             // I2C address of display
+#define hell_pixel_microseconds 4025
+#define program_memory_limit_consec_spaces 1
+#define serial_leading_zeros 1            // set to 1 to activate leading zeros in serial numbers (i.e. #1 = 001)
+#define serial_cut_numbers 0              // set to 1 to activate cut numbers in serial numbers (i.e. #10 = 1T, #19 = 1N)
+#define go_to_sleep_inactivity_time 10    // minutes - FEATURE_SLEEP
+#define default_cmos_super_keyer_iambic_b_timing_percent 33 // use with FEATURE_CMOS_SUPER_KEYER_IAMBIC_B_TIMING; should be between 0 to 99 % (0% = true iambic b;100% = iambic a behavior)
+#define cw_echo_timing_factor 0.25
+#define winkey_paddle_echo_buffer_decode_timing_factor 0.25
+#define potentiometer_always_on 0
+#define ptt_interlock_check_every_ms 100
+#define ptt_interlock_active_state HIGH
+#define unknown_cw_character '*'
+#define cli_paddle_echo_on_at_boot 1
+#define cli_straight_key_echo_on_at_boot 1
+#define tx_key_dit_and_dah_pins_active_state HIGH
+#define tx_key_dit_and_dah_pins_inactive_state LOW
+#define potentiometer_check_interval_ms 150
+#define potentiometer_reading_threshold 1 
+#define default_paddle_interruption_quiet_time_element_lengths 0
+#define default_wordsworth_wordspace 6
+#define default_wordsworth_repetition 1
+#define serial_program_memory_buffer_size 500
+#define eeprom_write_time_ms 30000
+
+#ifdef FEATURE_COMMAND_BUTTONS
+  #define analog_buttons_number_of_buttons 5  // includes the command button (command button + 3 memory buttons = 4)
+  #define analog_buttons_r1 10
+  #define analog_buttons_r2 1
+#endif
+
+
+#if defined(FEATURE_COMMAND_BUTTONS) &&  !defined(FEATURE_PS2_KEYBOARD) && !defined(FEATURE_USB_KEYBOARD) && !defined(FEATURE_COMMAND_LINE_INTERFACE) && !defined(FEATURE_WINKEY_EMULATION)
+  #define number_of_memories byte(analog_buttons_number_of_buttons-1)
+#else
+  #define number_of_memories byte(12)
+#endif
+
+#ifdef FEATURE_CAPACITIVE_PADDLE_PINS
+  #define capacitance_threshold 2
+#endif //FEATURE_CAPACITIVE_PADDLE_PINS
+
+#ifdef FEATURE_LED_RING
+  #define led_ring_low_limit 10
+  #define led_ring_high_limit 50
+#endif //FEATURE_LED_RING
+
+#ifdef FEATURE_QLF
+  #define qlf_dit_max 125
+  #define qlf_dit_min 75
+  #define qlf_dah_max 200
+  #define qlf_dah_min 100
+  #define qlf_on_by_default 0
+#endif //FEATURE_QLF
+
+
+#ifdef FEATURE_WINKEY_EMULATION
+  #ifdef OPTION_WINKEY_UCXLOG_9600_BAUD || defined(FEATURE_SO2R_BASE)
+    #define WINKEY_DEFAULT_BAUD 9600
+  #else
+    #define WINKEY_DEFAULT_BAUD 1200
+  #endif //OPTION_WINKEY_UCXLOG_9600_BAUD  || FEATURE_SO2R_BASE
+// alter these below to map alternate sidetones for Winkey interface protocol emulation
+#ifdef OPTION_WINKEY_2_SUPPORT
+	#define WINKEY_SIDETONE_1 3759
+	#define WINKEY_SIDETONE_2 1879
+	#define WINKEY_SIDETONE_3 1252
+	#define WINKEY_SIDETONE_4 940
+	#define WINKEY_SIDETONE_5 752
+	#define WINKEY_SIDETONE_6 625
+	#define WINKEY_SIDETONE_7 535
+	#define WINKEY_SIDETONE_8 469
+	#define WINKEY_SIDETONE_9 417
+	#define WINKEY_SIDETONE_10 375
+#else //OPTION_WINKEY_2_SUPPORT
+	#define WINKEY_SIDETONE_1 4000
+	#define WINKEY_SIDETONE_2 2000
+	#define WINKEY_SIDETONE_3 1333
+	#define WINKEY_SIDETONE_4 1000
+	#define WINKEY_SIDETONE_5 800
+	#define WINKEY_SIDETONE_6 666
+	#define WINKEY_SIDETONE_7 571
+	#define WINKEY_SIDETONE_8 500
+	#define WINKEY_SIDETONE_9 444
+	#define WINKEY_SIDETONE_10 400
+#endif //OPTION_WINKEY_2_SUPPORT
+
+#define WINKEY_1_REPORT_VERSION_NUMBER 10
+#define WINKEY_2_REPORT_VERSION_NUMBER 23
+
+// alter these to map to alternate hang time wordspace units
+#define WINKEY_HANG_TIME_1_0 1.0
+#define WINKEY_HANG_TIME_1_33 1.33
+#define WINKEY_HANG_TIME_1_66 1.66
+#define WINKEY_HANG_TIME_2_0 2.0
+
+#define WINKEY_RETURN_THIS_FOR_ADMIN_GET_CAL 0x16
+#define WINKEY_RETURN_THIS_FOR_ADMIN_PADDLE_A2D 0xEE
+#define WINKEY_RETURN_THIS_FOR_ADMIN_SPEED_A2D 0x00
+
+#endif //FEATURE_WINKEY_EMULATION
+
+
+
+#define PRIMARY_SERIAL_PORT &Serial
+#define PRIMARY_SERIAL_PORT_BAUD 115200     // This applies only when the port is in Command Line Interface mode.  In Winkey mode it will default to 1200.
+
+#ifdef FEATURE_COMMAND_LINE_INTERFACE_ON_SECONDARY_PORT
+  #define SECONDARY_SERIAL_PORT &Serial1
+  #define SECONDARY_SERIAL_PORT_BAUD 115200
+#endif
+
+
+#define CW_DECODER_SCREEN_COLUMNS 120        // word wrap at this many columns
+#define CW_DECODER_SPACE_PRINT_THRESH 4.5   // print space if no tone for this many element lengths
+#define CW_DECODER_SPACE_DECODE_THRESH 2.0  // invoke character decode if no tone for this many element lengths
+#define CW_DECODER_NOISE_FILTER 20          // ignore elements shorter than this (mS)
+
+#define STRAIGHT_KEY_ACTIVE_STATE LOW
+
+#ifdef FEATURE_DYNAMIC_DAH_TO_DIT_RATIO
+  #define DYNAMIC_DAH_TO_DIT_RATIO_LOWER_LIMIT_WPM 30
+  #define DYNAMIC_DAH_TO_DIT_RATIO_LOWER_LIMIT_RATIO 300 // 300 = 3:1 ratio
+  #define DYNAMIC_DAH_TO_DIT_RATIO_UPPER_LIMIT_WPM 70
+  #define DYNAMIC_DAH_TO_DIT_RATIO_UPPER_LIMIT_RATIO 240 // 240 = 2.4:1 ratio
+#endif //FEATURE_DYNAMIC_DAH_TO_DIT_RATIO
+
+#if defined(FEATURE_COMPETITION_COMPRESSION_DETECTION)
+  #define COMPETITION_COMPRESSION_DETECTION_ARRAY_SIZE 16
+  #define COMPETITION_COMPRESSION_DETECTION_TIME_INTERCHAR_LOWER_LIMIT 1
+  #define COMPETITION_COMPRESSION_DETECTION_TIME_INTERCHAR_UPPER_LIMIT 6.0
+  #define COMPETITION_COMPRESSION_DETECTION_AVERAGE_ALARM_THRESHOLD 3.0
+#endif //FEATURE_COMPETITION_COMPRESSION_DETECTION
+
+#if defined(FEATURE_SLEEP)
+  #define KEYER_AWAKE_PIN_AWAKE_STATE HIGH
+  #define KEYER_AWAKE_PIN_ASLEEP_STATE LOW
+#endif 
+
+#if defined(FEATURE_ETHERNET)
+  // #define FEATURE_ETHERNET_IP {192,168,1,178}                      // default IP address ("192.168.1.178")
+  // #define FEATURE_ETHERNET_MAC {0xDE,0xAD,0xBE,0xEF,0xFE,0xED}
+  #define FEATURE_ETHERNET_IP {192,168,1,179}                      // default IP address ("192.168.1.179")
+  #define FEATURE_ETHERNET_MAC {0xDE,0xAD,0xBE,0xEF,0xFE,0xEE}
+
+  #define FEATURE_ETHERNET_GATEWAY {192,168,1,1}                   // default gateway
+  #define FEATURE_ETHERNET_SUBNET_MASK {255,255,255,0}                  // default subnet mask
+  #define FEATURE_ETHERNET_WEB_LISTENER_PORT 80
+  #define FEATURE_UDP_SEND_BUFFER_SIZE 128
+  #define FEATURE_UDP_RECEIVE_BUFFER_SIZE 128
+#endif //FEATURE_ETHERNET
+
+#define WEB_SERVER_CONTROL_TX_KEY_TIME_LIMIT_SECS 10
+
+#define FEATURE_INTERNET_LINK_MAX_LINKS 2
+#define FEATURE_INTERNET_LINK_DEFAULT_RCV_UDP_PORT 8888
+#define FEATURE_INTERNET_LINK_BUFFER_TIME_MS 500 
+
+#if defined(FEATURE_4x4_KEYPAD)|| defined (FEATURE_3x4_KEYPAD)
+  #define KEYPAD_ROWS 4 //KeyPad Rows
+  #if defined(FEATURE_4x4_KEYPAD)
+    #define KEYPAD_COLS 4 //keypad Columns
+  #else
+    #define KEYPAD_COLS 3
+  #endif
+  #define mem1 0 //Memory numbers for Keypad: Actual memory numbers start with "0"
+  #define mem2 1
+  #define mem3 2
+  #define mem4 3
+  #define mem5 4
+  #define mem6 5
+  #define mem7 6
+  #define mem8 7
+  #define mem9 8
+  #define mem10 9
+  #define mem11 10
+  #define mem12 11
+#endif //#if defined(FEATURE_4x4_KEYPAD)|| defined (FEATURE_3x4_KEYPAD)
+
+#define initial_sidetone_mode 1            // Sidetone mode, 0=OFF, 1=ON, 2=PADDLE_ONLY
+
+#define sd_card_spi_ss_line 4
+
+#if defined(OPTION_DFROBOT_LCD_COMMAND_BUTTONS)
+
+  // For V1.1 board use these values
+  #define dfrobot_btnRIGHT_analog 50
+  #define dfrobot_btnUP_analog 250
+  #define dfrobot_btnDOWN_analog 450
+  #define dfrobot_btnLEFT_analog 650
+  #define dfrobot_btnSELECT_analog 850  
+
+  // For V1.0 board use these values
+  // #define dfrobot_btnRIGHT_analog 50
+  // #define dfrobot_btnUP_analog 195
+  // #define dfrobot_btnDOWN_analog 380
+  // #define dfrobot_btnLEFT_analog 555
+  // #define dfrobot_btnSELECT_analog 790  
+  
+  // button to memory mappings (0 = command button, 1 = memory 1, 2 = memory 2, etc.)
+  #define dfrobot_btnRIGHT  2
+  #define dfrobot_btnUP     1
+  #define dfrobot_btnDOWN   3
+  #define dfrobot_btnLEFT   4
+  #define dfrobot_btnSELECT 0
+  #define dfrobot_btnNONE   255 // do not change
+
+#endif
+
+#define sequencer_pins_active_state HIGH
+#define sequencer_pins_inactive_state LOW
+#define ptt_line_active_state HIGH
+#define ptt_line_inactive_state LOW
+#define tx_key_line_active_state HIGH
+#define tx_key_line_inactive_state LOW
+#define ptt_input_pin_active_state LOW
+#define ptt_input_pin_inactive_state HIGH
+#define tx_inhibit_pin_active_state LOW
+#define tx_inhibit_pin_inactive_state HIGH
+#define tx_pause_pin_active_state LOW
+#define tx_pause_pin_inactive_state HIGH
+
+#if defined(ARDUINO_MAPLE_MINI)
+  #define button_value_factor 4095  //sp5iou contributed
+#else
+  #define button_value_factor 1023
+#endif
+
+#define farnsworth_timing_calibration 1.15
+
+#define sidetone_volume_low_limit 10
+#define sidetone_volume_high_limit 500


### PR DESCRIPTION
Hi,
I've added support for the Funtronics FK-11. 

Steps I didn't commit, but mentioned in keyer_hardware.h 'notes' (don't know if you want that):
- The FaBo_212_LCD_PCF8574 libary, with slave address set to 0x27.
- `#define BOARD_MEGA_ADK` in the USB_Host_Shield/settings.h file.
- Uncommented the three lines below 'note_usb_uncomment_lines' in k3ng_keyer.ino.

Regards,
Ben