### PR TITLE
Paddle direction parameter change

### DIFF
--- a/k3ng_keyer/k3ng_keyer.ino
+++ b/k3ng_keyer/k3ng_keyer.ino
@@ -7847,10 +7847,10 @@ void command_tuning_mode() {
         }
       }
     }
-   if ((analogbuttonread(0)) || ((paddle_pin_read(paddle_left) == LOW) && (paddle_pin_read(paddle_right) == LOW))) { // if paddles are squeezed or button0 pressed - exit
-     looping = 0;
-   }
-   
+    if ((analogbuttonread(0)) || ((paddle_pin_read(paddle_left) == LOW) && (paddle_pin_read(paddle_right) == LOW))) { // if paddles are squeezed or button0 pressed - exit
+      looping = 0;
+    }
+  
   }
   sending_mode = MANUAL_SENDING;
   tx_and_sidetone_key(0);
@@ -7862,10 +7862,8 @@ void command_tuning_mode() {
   dah_buffer = 0;
 }
 #endif //FEATURE_COMMAND_BUTTONS
+	
 //-------------------------------------------------------------------------------------------------------
-
-
-
 
 // #if defined(FEATURE_SINEWAVE_SIDETONE)
 //   void sidetone_adj(int hz) {
@@ -7882,10 +7880,9 @@ void command_tuning_mode() {
 //         }
 //       #endif   
 //     }
-
 //   }
 
-// #else //FEATURE_SINEWAVE_SIDETONE
+// #else // FEATURE_SINEWAVE_SIDETONE
 
   void sidetone_adj(int hz) {
 
@@ -7900,16 +7897,15 @@ void command_tuning_mode() {
         }
       #endif   
     }
-
   }
 
-// #endif //FEATURE_SINEWAVE_SIDETONE
+// #endif // FEATURE_SINEWAVE_SIDETONE
 
 //-------------------------------------------------------------------------------------------------------
 
 // #if defined(FEATURE_SINEWAVE_SIDETONE)
 
-// void sidetone_adj_volume(int vo) { //dl2dbg
+// void sidetone_adj_volume(int vo) {                            //dl2dbg
 
 //   if ((vo > 0) && ((configuration.sidetone_volume + vo) > sidetone_volume_high_limit)){
 //     configuration.sidetone_volume = sidetone_volume_high_limit;
@@ -7919,33 +7915,28 @@ void command_tuning_mode() {
 //       configuration.sidetone_volume = sidetone_volume_low_limit;
 //       config_dirty = 1;
 //     } else {
-//         if (((configuration.sidetone_volume + vo) >= sidetone_volume_low_limit) && ((configuration.sidetone_volume + vo) <= sidetone_volume_high_limit)){
-//           configuration.sidetone_volume = configuration.sidetone_volume + vo;
-//           config_dirty = 1;
-//         }
+//       if (((configuration.sidetone_volume + vo) >= sidetone_volume_low_limit) && ((configuration.sidetone_volume + vo) <= sidetone_volume_high_limit)){
+//         configuration.sidetone_volume = configuration.sidetone_volume + vo;
+//         config_dirty = 1;
+//       }
 //     }
 //   }
-
-
-
-
-
 //   if (config_dirty) {
 //     compute_sinetone(configuration.hz_sidetone,configuration.sidetone_volume);
 //     #if defined(FEATURE_DISPLAY) && defined(OPTION_MORE_DISPLAY_MSGS)
-//       if (LCD_COLUMNS < 9){
+//       if (LCD_COLUMNS < 9) {
 //         lcd_center_print_timed(String(map(configuration.sidetone_volume,sidetone_volume_low_limit,sidetone_volume_high_limit,0,100)) + "%", 0, default_display_msg_delay);
 //       } else {
 //         lcd_center_print_timed("Sidetone " + String(map(configuration.sidetone_volume,sidetone_volume_low_limit,sidetone_volume_high_limit,0,100)) + "%", 0, default_display_msg_delay);
 //       }
 //     #endif   
 //   }
-
 // }
 
 // #endif //FEATURE_SINEWAVE_SIDETONE
 
 //-------------------------------------------------------------------------------------------------------
+	
 #if defined(FEATURE_COMMAND_BUTTONS) && !defined(OPTION_SIDETONE_DIGITAL_OUTPUT_NO_SQUARE_WAVE)
 void command_sidetone_freq_adj() {
 
@@ -7963,28 +7954,44 @@ void command_sidetone_freq_adj() {
     tone(sidetone_line, configuration.hz_sidetone);
     if (paddle_pin_read(paddle_left) == LOW) {
       #ifdef FEATURE_DISPLAY
-        sidetone_adj(5);   
+	#ifdef OPTION_SWAP_PADDLE_PARAMETER_CHANGE_DIRECTION
+	  sidetone_adj(-5);
+	#else
+	  sidetone_adj(5);
+	#endif                                               // OPTION_SWAP_PADDLE_PARAMETER_CHANGE_DIRECTION  
         if (LCD_COLUMNS < 9){
           lcd_center_print_timed(String(configuration.hz_sidetone) + " Hz", 0, default_display_msg_delay);
         } else {   
           lcd_center_print_timed("Sidetone " + String(configuration.hz_sidetone) + " Hz", 0, default_display_msg_delay);  
         }      
       #else
-        sidetone_adj(1);
-      #endif
+	#ifdef OPTION_SWAP_PADDLE_PARAMETER_CHANGE_DIRECTION
+	  sidetone_adj(-1);
+	#else
+	  sidetone_adj(1);
+	#endif                                              // OPTION_SWAP_PADDLE_PARAMETER_CHANGE_DIRECTION
+      #endif                                                // FEATURE_DISPLAY
       delay(10);
     }
     if (paddle_pin_read(paddle_right) == LOW) {
       #ifdef FEATURE_DISPLAY
-        sidetone_adj(-5);
+	#ifdef OPTION_SWAP_PADDLE_PARAMETER_CHANGE_DIRECTION
+	  sidetone_adj(5);  
+	#else
+	  sidetone_adj(-5);
+	#endif                                              // OPTION_SWAP_PADDLE_PARAMETER_CHANGE_DIRECTION
         if (LCD_COLUMNS < 9){
           lcd_center_print_timed(String(configuration.hz_sidetone) + " Hz", 0, default_display_msg_delay);
         } else {   
           lcd_center_print_timed("Sidetone " + String(configuration.hz_sidetone) + " Hz", 0, default_display_msg_delay);  
         }        
       #else
-        sidetone_adj(-1);
-      #endif
+        #ifdef OPTION_SWAP_PADDLE_PARAMETER_CHANGE_DIRECTION
+	   sidetone_adj(1); 
+        #else
+	    sidetone_adj(-1);
+	#endif                                              // OPTION_SWAP_PADDLE_PARAMETER_CHANGE_DIRECTION
+      #endif                                                // FEATURE_DISPLAY
       delay(10);
     }
     while ((paddle_pin_read(paddle_left) == LOW && paddle_pin_read(paddle_right) == LOW) || (analogbuttonread(0))) { // if paddles are squeezed or button0 pressed - exit
@@ -7998,13 +8005,11 @@ void command_sidetone_freq_adj() {
   }
   while (paddle_pin_read(paddle_left) == LOW || paddle_pin_read(paddle_right) == LOW || analogbuttonread(0) ) {}  // wait for all lines to go high
   noTone(sidetone_line);
-
 }
-#endif //FEATURE_COMMAND_BUTTONS
-
-
+#endif                                                        //FEATURE_COMMAND_BUTTONS
 
 //-------------------------------------------------------------------------------------------------------
+
 // #if defined(FEATURE_COMMAND_BUTTONS) && !defined(OPTION_SIDETONE_DIGITAL_OUTPUT_NO_SQUARE_WAVE) && defined(FEATURE_SINEWAVE_SIDETONE)
 // void command_sidetone_volume_adj() {
 
@@ -8062,13 +8067,11 @@ void command_sidetone_freq_adj() {
 //   noTone(sidetone_line);
 
 // }
-// #endif //defined(FEATURE_COMMAND_BUTTONS) && !defined(OPTION_SIDETONE_DIGITAL_OUTPUT_NO_SQUARE_WAVE) && defined(FEATURE_SINEWAVE_SIDETONE)
-
+// #endif // defined(FEATURE_COMMAND_BUTTONS) && !defined(OPTION_SIDETONE_DIGITAL_OUTPUT_NO_SQUARE_WAVE) && defined(FEATURE_SINEWAVE_SIDETONE)
 
 //-------------------------------------------------------------------------------------------------------
 #ifdef FEATURE_COMMAND_BUTTONS
-void command_speed_mode(byte mode)
-{
+void command_speed_mode(byte mode) {
 
   byte looping = 1;
   #ifndef FEATURE_DISPLAY
@@ -8098,17 +8101,33 @@ void command_speed_mode(byte mode)
   while (looping) {
     send_dit();
     if ((paddle_pin_read(paddle_left) == LOW)) {
-      if (mode == COMMAND_SPEED_MODE_KEYER_WPM){
-        speed_change(1);
+      if (mode == COMMAND_SPEED_MODE_KEYER_WPM) {
+        #ifdef OPTION_SWAP_PADDLE_PARAMETER_CHANGE_DIRECTION
+	  speed_change(-1);
+	#else
+	  speed_change(1);
+	#endif                                      // OPTION_SWAP_PADDLE_PARAMETER_CHANGE_DIRECTION
       } else {
-        speed_change_command_mode(1);
-      }
-    }
-    if ((paddle_pin_read(paddle_right) == LOW)) {
-      if (mode == COMMAND_SPEED_MODE_KEYER_WPM){
-        speed_change(-1);
-      } else {
+      #ifdef OPTION_SWAP_PADDLE_PARAMETER_CHANGE_DIRECTION
         speed_change_command_mode(-1);
+      #else
+        speed_change_command_mode(1);
+      #endif                                        // OPTION_SWAP_PADDLE_PARAMETER_CHANGE_DIRECTION
+      }                                             // endif (mode == COMMAND_SPEED_MODE_KEYER_WPM)
+    }                                               // end while looping
+    if ((paddle_pin_read(paddle_right) == LOW)) {
+      if (mode == COMMAND_SPEED_MODE_KEYER_WPM) {
+        #ifdef OPTION_SWAP_PADDLE_PARAMETER_CHANGE_DIRECTION
+          speed_change(1);
+	#else
+          speed_change(-1);
+	#endif                                      // OPTION_SWAP_PADDLE_PARAMETER_CHANGE_DIRECTION
+      } else {
+        #ifdef OPTION_SWAP_PADDLE_PARAMETER_CHANGE_DIRECTION
+          speed_change_command_mode(1);
+	#else
+          speed_change_command_mode(-1);
+	#endif                                      // OPTION_SWAP_PADDLE_PARAMETER_CHANGE_DIRECTION
       }
     }
     while ((paddle_pin_read(paddle_left) == LOW && paddle_pin_read(paddle_right) == LOW) || (analogbuttonread(0) ))  // if paddles are squeezed or button0 pressed - exit
@@ -8140,11 +8159,11 @@ void command_speed_mode(byte mode)
     send_char(c[1],KEYER_NORMAL);    
   #endif
 
- 
-
 }
 #endif //FEATURE_COMMAND_BUTTONS
+	
 //------------------------------------------------------------------
+	
 #ifndef FEATURE_DISPLAY
 void send_tx() {
 
@@ -8261,8 +8280,7 @@ byte analogbuttonread(byte button_number) {
 //------------------------------------------------------------------
 
 #ifdef FEATURE_COMMAND_BUTTONS
-void check_command_buttons()
-{
+void check_command_buttons() {
 
   #ifdef DEBUG_LOOP
     debug_serial_port->println(F("loop: entering check_buttons"));
@@ -8346,8 +8364,12 @@ void check_command_buttons()
         key_tx = 0;
         // do stuff if this is a command button hold down
         while (button_array.Held(analogbuttontemp)) {
-          if (paddle_pin_read(paddle_left) == LOW) {                     // left paddle increase speed
-            speed_change(1);
+          if (paddle_pin_read(paddle_left) == LOW) { 
+ 	    #ifdef OPTION_SWAP_PADDLE_PARAMETER_CHANGE_DIRECTION
+              speed_change(-1);                                           // left paddle decrease speed
+	    #else
+	      speed_change(1);                                            // left paddle increase speed
+	    #endif                                                        // OPTION_SWAP_PADDLE_PARAMETER_CHANGE_DIRECTION
             previous_sidetone_mode = configuration.sidetone_mode;
             configuration.sidetone_mode = SIDETONE_ON; 
             sending_mode = MANUAL_SENDING;
@@ -8357,8 +8379,12 @@ void check_command_buttons()
             dit_buffer = 0;
             
             #ifdef DEBUG_BUTTONS
-              debug_serial_port->println(F("\ncheck_buttons: speed_change(1)"));
-            #endif //DEBUG_BUTTONS            
+	      #ifdef OPTION_SWAP_PADDLE_PARAMETER_CHANGE_DIRECTION
+		debug_serial_port->println(F("\ncheck_buttons: speed_change(-1)"));
+ 	      #else
+		debug_serial_port->println(F("\ncheck_buttons: speed_change(1)"));
+	      #endif                                                 // OPTION_SWAP_PADDLE_PARAMETER_CHANGE_DIRECTION                                                      
+            #endif                                                   // DEBUG_BUTTONS            
 
             #if defined(FEATURE_WINKEY_EMULATION) && defined(FEATURE_POTENTIOMETER)
               if ((primary_serial_port_mode == SERIAL_WINKEY_EMULATION) && (winkey_host_open)) {
@@ -8368,8 +8394,12 @@ void check_command_buttons()
             #endif
 
           }
-          if (paddle_pin_read(paddle_right) == LOW) {                    // right paddle decreases speed
-            speed_change(-1);
+          if (paddle_pin_read(paddle_right) == LOW) {
+ 	    #ifdef OPTION_SWAP_PADDLE_PARAMETER_CHANGE_DIRECTION
+              speed_change(1);                                           // right paddle increase speed
+	    #else
+	      speed_change(-1);                                          // right paddle decrease speed
+	    #endif                                                       
             previous_sidetone_mode = configuration.sidetone_mode;
             configuration.sidetone_mode = SIDETONE_ON; 
             sending_mode = MANUAL_SENDING;
@@ -8379,8 +8409,12 @@ void check_command_buttons()
             dah_buffer = 0;
 
             #ifdef DEBUG_BUTTONS
-              debug_serial_port->println(F("\ncheck_buttons: speed_change(-1)"));
-            #endif //DEBUG_BUTTONS            
+	      #ifdef OPTION_SWAP_PADDLE_PARAMETER_CHANGE_DIRECTION
+                debug_serial_port->println(F("\ncheck_buttons: speed_change(1)"));
+	      #else
+                debug_serial_port->println(F("\ncheck_buttons: speed_change(-1)"));
+              #endif                                // OPTION_SWAP_PADDLE_PARAMETER_CHANGE_DIRECTION
+            #endif                                  // DEBUG_BUTTONS            
 
             #if defined(FEATURE_WINKEY_EMULATION) && defined(FEATURE_POTENTIOMETER)
               if ((primary_serial_port_mode == SERIAL_WINKEY_EMULATION) && (winkey_host_open)) {
@@ -8391,7 +8425,7 @@ void check_command_buttons()
           }
         }
         key_tx = 1;
-      }  //(analogbuttontemp == 0)
+      }  // (analogbuttontemp == 0)
       if ((analogbuttontemp > 0) && (analogbuttontemp < analog_buttons_number_of_buttons)) {
         while (button_array.Held(analogbuttontemp)) {
           if (((paddle_pin_read(paddle_left) == LOW) || (paddle_pin_read(paddle_right) == LOW)) && (analogbuttontemp < (number_of_memories + 1))){
@@ -8415,7 +8449,7 @@ void check_command_buttons()
             configuration.sidetone_mode = previous_sidetone_mode;
         }
       }
-    //} // button hold
+    //}                                  // button hold
   }
   last_button_action = millis();
   #ifdef FEATURE_SLEEP
@@ -8423,7 +8457,7 @@ void check_command_buttons()
   #endif //FEATURE_SLEEP
   
 }
-#endif //FEATURE_COMMAND_BUTTONS
+#endif                                    // FEATURE_COMMAND_BUTTONS
 
 //-------------------------------------------------------------------------------------------------------
 

--- a/k3ng_keyer/keyer_features_and_options.h
+++ b/k3ng_keyer/keyer_features_and_options.h
@@ -113,5 +113,6 @@
 
 // #define OPTION_EXCLUDE_MILL_MODE
 
-//#define OPTION_ENABLE_SERIAL_PORT_CHECKING_WHILE_SENDING_CW_MAY_CAUSE_PROBLEMS
+// #define OPTION_ENABLE_SERIAL_PORT_CHECKING_WHILE_SENDING_CW_MAY_CAUSE_PROBLEMS
+// #define OPTION_SWAP_PADDLE_PARAMETER_CHANGE_DIRECTION        // reverses the up/down direction when using the paddles to change the wpm or sidetone frequency
 


### PR DESCRIPTION
Added an option so that the left paddle decreases the speed/sidetone and the right paddle increases the speed/sidetone. Could be more intuitive since 'dials to the right' implies more of ...
The new option OPTION_SWAP_PADDLE_PARAMETER_CHANGE_DIRECTION controls whether this swap is in effect or not. Unless the option is defined, then the previously coded paddle directions will be implemented.
There is no increase in the compiled code size, since either way, only one piece of code is included in the final compiled code, as was the case before adding this option.