### PR TITLE
Update k3ng_keyer.ino

### DIFF
--- a/k3ng_keyer/k3ng_keyer.ino
+++ b/k3ng_keyer/k3ng_keyer.ino
@@ -7552,7 +7552,7 @@ void command_mode() {
 
 void command_display_memory(byte memory_number) {
  
-  #ifdef FEATURE_DISPLAY
+  #if defined(FEATURE_DISPLAY) && defined(FEATURE_MEMORIES)
     byte eeprom_byte_read = 0;
     char memory_char[LCD_COLUMNS];                                                        // an array of char to hold the retrieved memory from EEPROM
     int j;


### PR DESCRIPTION
The old code can cause a compiler error if FEATURE_MEMORIES is not defined, since then the variable memory_start(memory_number) is also undefined. Leading to a compiler error.
So, this function is also excluded from the compile if  FEATURE_MEMORIES is not defined.