### PR TITLE
Update k3ng_keyer.ino

### DIFF
--- a/k3ng_keyer/k3ng_keyer.ino
+++ b/k3ng_keyer/k3ng_keyer.ino
@@ -7552,7 +7552,7 @@ void command_mode() {
 
 void command_display_memory(byte memory_number) {
  
-  #ifdef FEATURE_DISPLAY
+  #if defined(FEATURE_DISPLAY) && defined(FEATURE_MEMORIES)
     byte eeprom_byte_read = 0;
     char memory_char[LCD_COLUMNS];                                                        // an array of char to hold the retrieved memory from EEPROM
     int j;


### PR DESCRIPTION
Fix for a compiler error issue if FEATURE_MEMORIES is not defined.
Bug introduced when I added display functionality to display the memory contents from within Command Mode, and I forgot to make sure that in fact there were any memories in the keyer.