### PR TITLE
Fixed error : call of overloaded 'noTone(<anonymous enum>)' is ambiguous

### DIFF
--- a/k3ng_keyer/keyer_stm32duino.h
+++ b/k3ng_keyer/keyer_stm32duino.h
@@ -34,6 +34,6 @@
   void service_send_buffer(byte);
   void check_ptt_tail(void);
   void check_for_dirty_configuration(void);
-  void tone(uint8_t, short unsigned int, unsigned int);
-  void noTone(uint8_t);
+  void tone(uint32_t, uint32_t, uint32_t);
+  void noTone(uint32_t);
   void serial_status(PRIMARY_SERIAL_CLS*);


### PR DESCRIPTION
When using HARDWARE_GENERIC_STM32F103C by enabling in keyer_hardware.h, the error [call of overloaded 'noTone(<anonymous enum>)' is ambiguous] has occured.
This error happens because of type mismatch between keyer_stm32duino.h and tone.h in hardware folder.