### PR TITLE
Support for configuring the side tone line states.

### DIFF
--- a/k3ng_keyer/k3ng_keyer.ino
+++ b/k3ng_keyer/k3ng_keyer.ino
@@ -6556,7 +6556,7 @@ void tx_and_sidetone_key (int state)
           tone(sidetone_line, configuration.hz_sidetone);
         #else
           if (sidetone_line) {
-            digitalWrite(sidetone_line, HIGH);
+            digitalWrite(sidetone_line, sidetone_line_active_state);
           }
         #endif
       }
@@ -6577,7 +6577,7 @@ void tx_and_sidetone_key (int state)
             noTone(sidetone_line);
           #else
             if (sidetone_line) {
-              digitalWrite(sidetone_line, LOW);
+              digitalWrite(sidetone_line, sidetone_line_inactive_state);
             }
           #endif
         }
@@ -6606,7 +6606,7 @@ void tx_and_sidetone_key (int state)
           tone(sidetone_line, configuration.hz_sidetone);
         #else
           if (sidetone_line) {
-            digitalWrite(sidetone_line, HIGH);
+            digitalWrite(sidetone_line, sidetone_line_active_state);
           }
         #endif          
       }
@@ -6629,7 +6629,7 @@ void tx_and_sidetone_key (int state)
             noTone(sidetone_line);
           #else
             if (sidetone_line) {
-              digitalWrite(sidetone_line, LOW);
+              digitalWrite(sidetone_line, sidetone_line_inactive_state);
             }
           #endif
         }
@@ -9076,9 +9076,9 @@ void beep()
     // #endif
   #else
     if (sidetone_line) {
-      digitalWrite(sidetone_line, HIGH);
+      digitalWrite(sidetone_line, sidetone_line_active_state);
       delay(200);
-      digitalWrite(sidetone_line, LOW);
+      digitalWrite(sidetone_line, sidetone_line_inactive_state);
     }
   #endif
 }
@@ -9093,9 +9093,9 @@ void boop()
     noTone(sidetone_line);
   #else
     if (sidetone_line) {
-      digitalWrite(sidetone_line, HIGH);
+      digitalWrite(sidetone_line, sidetone_line_active_state);
       delay(100);
-      digitalWrite(sidetone_line, LOW);
+      digitalWrite(sidetone_line, sidetone_line_inactive_state);
     }
   #endif    
 }
@@ -9112,9 +9112,9 @@ void beep_boop()
     noTone(sidetone_line);
   #else
     if (sidetone_line) {
-      digitalWrite(sidetone_line, HIGH);
+      digitalWrite(sidetone_line, sidetone_line_active_state);
       delay(200);
-      digitalWrite(sidetone_line, LOW);
+      digitalWrite(sidetone_line, sidetone_line_inactive_state);
     }
   #endif     
 }
@@ -9131,9 +9131,9 @@ void boop_beep()
     noTone(sidetone_line);
   #else
     if (sidetone_line) {
-      digitalWrite(sidetone_line, HIGH);
+      digitalWrite(sidetone_line, sidetone_line_active_state);
       delay(200);
-      digitalWrite(sidetone_line, LOW);
+      digitalWrite(sidetone_line, sidetone_line_inactive_state);
     }
   #endif         
 }
@@ -17186,7 +17186,7 @@ void initialize_pins() {
   }
   if (sidetone_line) {
     pinMode (sidetone_line, OUTPUT);
-    digitalWrite (sidetone_line, LOW);
+    digitalWrite (sidetone_line, sidetone_line_inactive_state);
   }
   if (tx_key_dit) {
     pinMode (tx_key_dit, OUTPUT);

--- a/k3ng_keyer/keyer_settings.h
+++ b/k3ng_keyer/keyer_settings.h
@@ -262,6 +262,8 @@
 #define tx_inhibit_pin_inactive_state HIGH
 #define tx_pause_pin_active_state LOW
 #define tx_pause_pin_inactive_state HIGH
+#define sidetone_line_active_state HIGH
+#define sidetone_line_inactive_state LOW
 
 #if defined(ARDUINO_MAPLE_MINI)
   #define button_value_factor 4095  //sp5iou contributed

--- a/k3ng_keyer/keyer_settings_fk_10.h
+++ b/k3ng_keyer/keyer_settings_fk_10.h
@@ -284,6 +284,8 @@
 #define tx_inhibit_pin_inactive_state HIGH
 #define tx_pause_pin_active_state LOW
 #define tx_pause_pin_inactive_state HIGH
+#define sidetone_line_active_state HIGH
+#define sidetone_line_inactive_state LOW
 
 #if defined(ARDUINO_MAPLE_MINI)
   #define button_value_factor 4095  //sp5iou contributed

--- a/k3ng_keyer/keyer_settings_fk_11.h
+++ b/k3ng_keyer/keyer_settings_fk_11.h
@@ -266,6 +266,8 @@
 #define tx_inhibit_pin_inactive_state HIGH
 #define tx_pause_pin_active_state LOW
 #define tx_pause_pin_inactive_state HIGH
+#define sidetone_line_active_state HIGH
+#define sidetone_line_inactive_state LOW
 
 #if defined(ARDUINO_MAPLE_MINI)
   #define button_value_factor 4095  //sp5iou contributed

--- a/k3ng_keyer/keyer_settings_generic_STM32F103C.h
+++ b/k3ng_keyer/keyer_settings_generic_STM32F103C.h
@@ -271,6 +271,8 @@ GENERIC STM32F103C
 #define tx_inhibit_pin_inactive_state HIGH
 #define tx_pause_pin_active_state LOW
 #define tx_pause_pin_inactive_state HIGH
+#define sidetone_line_active_state HIGH
+#define sidetone_line_inactive_state LOW
 
 #if defined(ARDUINO_MAPLE_MINI) || defined(ARDUINO_GENERIC_STM32f103C) //sp5iou 20180329
   #define button_value_factor 4095  //sp5iou contributed

--- a/k3ng_keyer/keyer_settings_iz3gme.h
+++ b/k3ng_keyer/keyer_settings_iz3gme.h
@@ -264,6 +264,8 @@
 #define tx_inhibit_pin_inactive_state HIGH
 #define tx_pause_pin_active_state LOW
 #define tx_pause_pin_inactive_state HIGH
+#define sidetone_line_active_state HIGH
+#define sidetone_line_inactive_state LOW
 
 #if defined(ARDUINO_MAPLE_MINI)
   #define button_value_factor 4095  //sp5iou contributed

--- a/k3ng_keyer/keyer_settings_k5bcq.h
+++ b/k3ng_keyer/keyer_settings_k5bcq.h
@@ -263,6 +263,8 @@
 #define tx_inhibit_pin_inactive_state HIGH
 #define tx_pause_pin_active_state LOW
 #define tx_pause_pin_inactive_state HIGH
+#define sidetone_line_active_state HIGH
+#define sidetone_line_inactive_state LOW
 
 #if defined(ARDUINO_MAPLE_MINI)
   #define button_value_factor 4095  //sp5iou contributed

--- a/k3ng_keyer/keyer_settings_maple_mini.h
+++ b/k3ng_keyer/keyer_settings_maple_mini.h
@@ -276,6 +276,8 @@
 #define tx_inhibit_pin_inactive_state HIGH
 #define tx_pause_pin_active_state LOW
 #define tx_pause_pin_inactive_state HIGH
+#define sidetone_line_active_state HIGH
+#define sidetone_line_inactive_state LOW
 
 #if defined(ARDUINO_MAPLE_MINI)
   #define button_value_factor 4095  //sp5iou contributed

--- a/k3ng_keyer/keyer_settings_megakeyer.h
+++ b/k3ng_keyer/keyer_settings_megakeyer.h
@@ -269,6 +269,8 @@
 #define tx_inhibit_pin_inactive_state HIGH
 #define tx_pause_pin_active_state LOW
 #define tx_pause_pin_inactive_state HIGH
+#define sidetone_line_active_state HIGH
+#define sidetone_line_inactive_state LOW
 
 #if defined(ARDUINO_MAPLE_MINI)
   #define button_value_factor 4095  //sp5iou contributed

--- a/k3ng_keyer/keyer_settings_mortty.h
+++ b/k3ng_keyer/keyer_settings_mortty.h
@@ -265,6 +265,8 @@
 #define tx_inhibit_pin_inactive_state HIGH
 #define tx_pause_pin_active_state LOW
 #define tx_pause_pin_inactive_state HIGH
+#define sidetone_line_active_state HIGH
+#define sidetone_line_inactive_state LOW
 
 #if defined(ARDUINO_MAPLE_MINI)
   #define button_value_factor 4095

--- a/k3ng_keyer/keyer_settings_mortty_regular.h
+++ b/k3ng_keyer/keyer_settings_mortty_regular.h
@@ -265,6 +265,8 @@
 #define tx_inhibit_pin_inactive_state HIGH
 #define tx_pause_pin_active_state LOW
 #define tx_pause_pin_inactive_state HIGH
+#define sidetone_line_active_state HIGH
+#define sidetone_line_inactive_state LOW
 
 #if defined(ARDUINO_MAPLE_MINI)
   #define button_value_factor 4095

--- a/k3ng_keyer/keyer_settings_mortty_regular_with_potentiometer.h
+++ b/k3ng_keyer/keyer_settings_mortty_regular_with_potentiometer.h
@@ -265,6 +265,8 @@
 #define tx_inhibit_pin_inactive_state HIGH
 #define tx_pause_pin_active_state LOW
 #define tx_pause_pin_inactive_state HIGH
+#define sidetone_line_active_state HIGH
+#define sidetone_line_inactive_state LOW
 
 #if defined(ARDUINO_MAPLE_MINI)
   #define button_value_factor 4095

--- a/k3ng_keyer/keyer_settings_mortty_so2r.h
+++ b/k3ng_keyer/keyer_settings_mortty_so2r.h
@@ -265,6 +265,8 @@
 #define tx_inhibit_pin_inactive_state HIGH
 #define tx_pause_pin_active_state LOW
 #define tx_pause_pin_inactive_state HIGH
+#define sidetone_line_active_state HIGH
+#define sidetone_line_inactive_state LOW
 
 #if defined(ARDUINO_MAPLE_MINI)
   #define button_value_factor 4095

--- a/k3ng_keyer/keyer_settings_mortty_so2r_with_potentiometer.h
+++ b/k3ng_keyer/keyer_settings_mortty_so2r_with_potentiometer.h
@@ -265,6 +265,8 @@
 #define tx_inhibit_pin_inactive_state HIGH
 #define tx_pause_pin_active_state LOW
 #define tx_pause_pin_inactive_state HIGH
+#define sidetone_line_active_state HIGH
+#define sidetone_line_inactive_state LOW
 
 #if defined(ARDUINO_MAPLE_MINI)
   #define button_value_factor 4095

--- a/k3ng_keyer/keyer_settings_nanokeyer_rev_b.h
+++ b/k3ng_keyer/keyer_settings_nanokeyer_rev_b.h
@@ -256,6 +256,8 @@
 #define tx_inhibit_pin_inactive_state HIGH
 #define tx_pause_pin_active_state LOW
 #define tx_pause_pin_inactive_state HIGH
+#define sidetone_line_active_state HIGH
+#define sidetone_line_inactive_state LOW
 
 #if defined(ARDUINO_MAPLE_MINI)
   #define button_value_factor 4095  //sp5iou contributed

--- a/k3ng_keyer/keyer_settings_nanokeyer_rev_d.h
+++ b/k3ng_keyer/keyer_settings_nanokeyer_rev_d.h
@@ -257,6 +257,8 @@
 #define tx_inhibit_pin_inactive_state HIGH
 #define tx_pause_pin_active_state LOW
 #define tx_pause_pin_inactive_state HIGH
+#define sidetone_line_active_state HIGH
+#define sidetone_line_inactive_state LOW
 
 #if defined(ARDUINO_MAPLE_MINI)
   #define button_value_factor 4095  //sp5iou contributed

--- a/k3ng_keyer/keyer_settings_open_interface.h
+++ b/k3ng_keyer/keyer_settings_open_interface.h
@@ -259,6 +259,8 @@
 #define tx_inhibit_pin_inactive_state HIGH
 #define tx_pause_pin_active_state LOW
 #define tx_pause_pin_inactive_state HIGH
+#define sidetone_line_active_state HIGH
+#define sidetone_line_inactive_state LOW
 
 #if defined(ARDUINO_MAPLE_MINI)
   #define button_value_factor 4095  //sp5iou contributed

--- a/k3ng_keyer/keyer_settings_opencwkeyer_mk2.h
+++ b/k3ng_keyer/keyer_settings_opencwkeyer_mk2.h
@@ -264,6 +264,8 @@
 #define tx_inhibit_pin_inactive_state HIGH
 #define tx_pause_pin_active_state LOW
 #define tx_pause_pin_inactive_state HIGH
+#define sidetone_line_active_state HIGH
+#define sidetone_line_inactive_state LOW
 
 #if defined(ARDUINO_MAPLE_MINI)
   #define button_value_factor 4095  //sp5iou contributed

--- a/k3ng_keyer/keyer_settings_test.h
+++ b/k3ng_keyer/keyer_settings_test.h
@@ -280,6 +280,8 @@
 #define tx_inhibit_pin_inactive_state HIGH
 #define tx_pause_pin_active_state LOW
 #define tx_pause_pin_inactive_state HIGH
+#define sidetone_line_active_state HIGH
+#define sidetone_line_inactive_state LOW
 
 #if defined(ARDUINO_MAPLE_MINI)
   #define button_value_factor 4095

--- a/k3ng_keyer/keyer_settings_test_everything.h
+++ b/k3ng_keyer/keyer_settings_test_everything.h
@@ -277,6 +277,8 @@
 #define tx_inhibit_pin_inactive_state HIGH
 #define tx_pause_pin_active_state LOW
 #define tx_pause_pin_inactive_state HIGH
+#define sidetone_line_active_state HIGH
+#define sidetone_line_inactive_state LOW
 
 #if defined(ARDUINO_MAPLE_MINI)
   #define button_value_factor 4095

--- a/k3ng_keyer/keyer_settings_tinykeyer.h
+++ b/k3ng_keyer/keyer_settings_tinykeyer.h
@@ -257,6 +257,8 @@
 #define tx_inhibit_pin_inactive_state HIGH
 #define tx_pause_pin_active_state LOW
 #define tx_pause_pin_inactive_state HIGH
+#define sidetone_line_active_state HIGH
+#define sidetone_line_inactive_state LOW
 
 #if defined(ARDUINO_MAPLE_MINI)
   #define button_value_factor 4095  //sp5iou contributed

--- a/k3ng_keyer/keyer_settings_yaacwk.h
+++ b/k3ng_keyer/keyer_settings_yaacwk.h
@@ -263,6 +263,8 @@
 #define tx_inhibit_pin_inactive_state HIGH
 #define tx_pause_pin_active_state LOW
 #define tx_pause_pin_inactive_state HIGH
+#define sidetone_line_active_state HIGH
+#define sidetone_line_inactive_state LOW
 
 #if defined(ARDUINO_MAPLE_MINI)
   #define button_value_factor 4095  //sp5iou contributed

--- a/k3ng_keyer/keyer_settings_yccc_so2r_mini.h
+++ b/k3ng_keyer/keyer_settings_yccc_so2r_mini.h
@@ -266,6 +266,8 @@
 #define tx_inhibit_pin_inactive_state HIGH
 #define tx_pause_pin_active_state LOW
 #define tx_pause_pin_inactive_state HIGH
+#define sidetone_line_active_state HIGH
+#define sidetone_line_inactive_state LOW
 
 #if defined(ARDUINO_MAPLE_MINI)
   #define button_value_factor 4095


### PR DESCRIPTION
There might be cases where the side tone digital line (no square wave generation, just a active beeper/buzzer attached) is active on LOW, not HIGH. For example the Arduino Multi Function Shield, a very convenient test platform. Therefore I added two defines in the spirit of the other active/inactive switches to control the HIGH/LOW states.

    #define sidetone_line_active_state HIGH
    #define sidetone_line_inactive_state LOW

Then, I used these defines to replace all corresponding occurrences for HIGH and LOW such as:

    digitalWrite(sidetone_line, HIGH);