### PR TITLE
Command buttons 1-3 are not working with ARDUINO_GENERIC_STM32F103C.

### DIFF
--- a/k3ng_keyer/src/buttonarray/buttonarray.h
+++ b/k3ng_keyer/src/buttonarray/buttonarray.h
@@ -7,7 +7,7 @@
 #define DEBOUNCE_MS 200
 #define NUMBER_OF_BUTTON_READS_TO_AVERAGE 19
 
-#if defined(ARDUINO_ARCH_ESP32)
+#if defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_GENERIC_STM32F103C)
     #define max_value 4095
 #else
     #define max_value 1023


### PR DESCRIPTION
I build a K3NG Keyer with ARDUINO_GENERIC_STM32F103C.
I noticed command buttons 1-3 are not working. (Only "Button - 0" is working).
This issue caused because the range of AnalogRead() was different.
So, I fixed the range of "max_value" in "buttonarray.h"

> #if defined(ARDUINO_ARCH_ESP32)
>     #define max_value 4095
> #else
>     #define max_value 1023
> #endif

↓ 

> #if defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_GENERIC_STM32F103C)
>     #define max_value 4095
> #else
>     #define max_value 1023
> #endif
