### PR TITLE
Change personalized startup operation

### DIFF
--- a/k3ng_keyer/k3ng_keyer.ino
+++ b/k3ng_keyer/k3ng_keyer.ino
@@ -17098,6 +17098,7 @@ void initialize_display(){
         } else if (LCD_ROWS > 2) {
 	  lcd_center_print_timed("hi", 1, 4000);                    // display 'hi' on the 2nd line anyway
           lcd_center_print_timed(custom_startup_field, 2, 4000);    // display the custom field on the third line of the display, maximum field length is the number of columns
+	}
       #else
         lcd_center_print_timed("hi", 1, 4000);
       #endif                                                        // OPTION_PERSONALIZED_STARTUP_SCREEN

--- a/k3ng_keyer/k3ng_keyer.ino
+++ b/k3ng_keyer/k3ng_keyer.ino
@@ -17088,36 +17088,39 @@ void initialize_display(){
       lcd.clear(); // you have to ;o)
     #endif //OPTION_DISPLAY_NON_ENGLISH_EXTENSIONS
 
-    if (LCD_COLUMNS < 9){
-      lcd_center_print_timed("K3NGKeyr",0,4000);
+     if (LCD_COLUMNS < 9) {
+      lcd_center_print_timed("K3NGKeyr", 0, 4000);
     } else {
-      lcd_center_print_timed("K3NG Keyer",0,4000);
+      lcd_center_print_timed("K3NG Keyer", 0, 4000);
+      #ifdef OPTION_PERSONALIZED_STARTUP_SCREEN
+        if (LCD_ROWS == 2) {
+          lcd_center_print_timed(custom_startup_field, 1, 4000);    // display the custom field on the second line of the display, maximum field length is the number of columns
+        } else if (LCD_ROWS > 2) {
+	  lcd_center_print_timed("hi", 1, 4000);                    // display 'hi' on the 2nd line anyway
+          lcd_center_print_timed(custom_startup_field, 2, 4000);    // display the custom field on the third line of the display, maximum field length is the number of columns
+      #else
+        lcd_center_print_timed("hi", 1, 4000);
+      #endif                                                        // OPTION_PERSONALIZED_STARTUP_SCREEN
+      if (LCD_ROWS > 3) lcd_center_print_timed("V: " + String(CODE_VERSION), 3, 4000);      // display the code version on the fourth line of the display
     }
   #endif //FEATURE_DISPLAY
 
   if (keyer_machine_mode != BEACON) {
     #ifndef OPTION_DO_NOT_SAY_HI
-      // say HI
+      // sound out HI
       // store current setting (compliments of DL2SBA - http://dl2sba.com/ )
-      byte oldKey = key_tx; 
+      byte oldKey = key_tx;
       byte oldSideTone = configuration.sidetone_mode;
       key_tx = 0;
       configuration.sidetone_mode = SIDETONE_ON;     
-      #ifdef FEATURE_DISPLAY
-        lcd_center_print_timed("h",1,4000);
-      #endif
       send_char('H',KEYER_NORMAL);
-      #ifdef FEATURE_DISPLAY
-        lcd_center_print_timed("hi",1,4000);
-      #endif
-      send_char('I',KEYER_NORMAL); 
-      configuration.sidetone_mode = oldSideTone; 
-      key_tx = oldKey;     
+      send_char('I',KEYER_NORMAL);
+      configuration.sidetone_mode = oldSideTone;
+      key_tx = oldKey;
     #endif //OPTION_DO_NOT_SAY_HI
     #ifdef OPTION_BLINK_HI_ON_PTT
       blink_ptt_dits_and_dahs(".... ..");
     #endif
-
   }
 }
 

--- a/k3ng_keyer/k3ng_keyer.ino
+++ b/k3ng_keyer/k3ng_keyer.ino
@@ -4769,7 +4769,8 @@ void check_rotary_encoder(){
   int step = chk_rotary_encoder();
 
   if (step != 0) {
-    speed_change(step);
+    if (keyer_machine_mode == KEYER_COMMAND_MODE) speed_change_command_mode(step);
+    else speed_change(step);
      
     // Start of Winkey Speed change mod for Rotary Encoder -- VE2EVN
     #ifdef FEATURE_WINKEY_EMULATION
@@ -4852,7 +4853,8 @@ void check_potentiometer()
         debug_serial_port->print(F(" analog read: "));
         debug_serial_port->println(analogRead(potentiometer));
       #endif
-      speed_set(pot_value_wpm_read);
+      if (keyer_machine_mode == KEYER_COMMAND_MODE) command_speed_set(pot_value_wpm_read);
+      else speed_set(pot_value_wpm_read);
       last_pot_wpm_read = pot_value_wpm_read;
       #ifdef FEATURE_WINKEY_EMULATION
         if ((primary_serial_port_mode == SERIAL_WINKEY_EMULATION) && (winkey_host_open)) {
@@ -6510,6 +6512,20 @@ void speed_set(int wpm_set){
   }
 }
 //-------------------------------------------------------------------------------------------------------
+
+void command_speed_set(int wpm_set) {
+  if ((wpm_set > 0) && (wpm_set < 1000)) {
+    configuration.wpm_command_mode = wpm_set;
+    config_dirty = 1;
+
+    #ifdef FEATURE_DISPLAY
+      lcd_center_print_timed("Cmd Spd " + String(configuration.wpm_command_mode) + " wpm", 0, default_display_msg_delay);
+    #endif                                                 // FEATURE_DISPLAY
+  }                                                        // end if
+}                                                          // end command_speed_set
+
+//-------------------------------------------------------------------------------------------------------
+
 #ifdef FEATURE_DISPLAY
   void lcd_center_print_timed_wpm(){
 


### PR DESCRIPTION
Changed slightly the way that the personalized startup operates.
If you have enabled OPTION_PERSONALIZED_STARTUP_SCREEN then, with a 2 line display it will no longer show 'hi' on the 2nd line but the personalized line will display.
OPTION_DO_NOT_SAY_HI only affects sidetone now, the screen display is determined by OPTION_PERSONALIZED_STARTUP_SCREEN.
With a 4 line display 'hi' will be on line 2, and if OPTION_PERSONALIZED_STARTUP_SCREEN is enabled then that will be displayed on line 3 and the code version on line 4.