### PR TITLE
"OPTION_WABUN_CODE" (Japanese text in morse code)

### DIFF
--- a/k3ng_keyer/k3ng_keyer.ino
+++ b/k3ng_keyer/k3ng_keyer.ino
@@ -9434,6 +9434,66 @@ void send_char(byte cw_char, byte omit_letterspace)
       case 238: send_the_dits_and_dahs("--.--");break;// 'ñ' LA3ZA
       case 226: send_the_dits_and_dahs("------");break;// 'ß' LA3ZA
       #endif //OPTION_NON_ENGLISH_EXTENSIONS   
+
+      
+      #if defined(OPTION_WABUN_CODE)
+      case 177  : send_the_dits_and_dahs("--.--"); break;   // ｱ
+      case 178  : send_the_dits_and_dahs(".-"); break;
+      case 179  : send_the_dits_and_dahs("..-"); break;
+      case 180  : send_the_dits_and_dahs("-.---"); break;
+      case 181  : send_the_dits_and_dahs(".-..."); break;
+      case 182  : send_the_dits_and_dahs(".-.."); break;
+      case 183  : send_the_dits_and_dahs("-.-.."); break;
+      case 184  : send_the_dits_and_dahs("...-"); break;
+      case 185  : send_the_dits_and_dahs("-.--"); break;
+      case 186  : send_the_dits_and_dahs("----"); break;
+      case 187  : send_the_dits_and_dahs("-.-.-"); break;
+      case 188  : send_the_dits_and_dahs("--.-."); break;
+      case 189  : send_the_dits_and_dahs("---.-"); break;
+      case 190  : send_the_dits_and_dahs(".---."); break;
+      case 191  : send_the_dits_and_dahs("---."); break;
+      case 192  : send_the_dits_and_dahs("-."); break;
+      case 193  : send_the_dits_and_dahs("..-."); break;
+      case 194  : send_the_dits_and_dahs(".--."); break;
+      case 195  : send_the_dits_and_dahs(".-.--"); break;
+      case 196  : send_the_dits_and_dahs("..-.."); break;
+      case 197  : send_the_dits_and_dahs(".-."); break;
+      case 198  : send_the_dits_and_dahs("-.-."); break;
+      case 199  : send_the_dits_and_dahs("...."); break;
+      case 200  : send_the_dits_and_dahs("--.-"); break;
+      case 201  : send_the_dits_and_dahs("..--"); break;
+      case 202  : send_the_dits_and_dahs("-..."); break;
+      case 203  : send_the_dits_and_dahs("--..-"); break;
+      case 204  : send_the_dits_and_dahs("--.."); break;
+      case 205  : send_the_dits_and_dahs("."); break;
+      case 206  : send_the_dits_and_dahs("-.."); break;
+      case 207  : send_the_dits_and_dahs("-..-"); break;
+      case 208  : send_the_dits_and_dahs("..-.-"); break;
+      case 209  : send_the_dits_and_dahs("-"); break;
+      case 210  : send_the_dits_and_dahs("-...-"); break;
+      case 211  : send_the_dits_and_dahs("-..-."); break;
+      case 212  : send_the_dits_and_dahs(".--"); break;
+      case 213  : send_the_dits_and_dahs("-..--"); break;
+      case 214  : send_the_dits_and_dahs("--"); break;
+      case 215  : send_the_dits_and_dahs("..."); break;
+      case 216  : send_the_dits_and_dahs("--."); break;
+      case 217  : send_the_dits_and_dahs("-.--."); break;
+      case 218  : send_the_dits_and_dahs("---"); break;
+      case 219  : send_the_dits_and_dahs(".-.-"); break;
+      case 220  : send_the_dits_and_dahs("-.-"); break;     // ﾜ
+      case 166  : send_the_dits_and_dahs(".---"); break;    // ｦ
+      case 221  : send_the_dits_and_dahs(".-.-."); break;   // ﾝ
+      case 222  : send_the_dits_and_dahs(".."); break;      // ﾞ
+      case 223  : send_the_dits_and_dahs("..--."); break;   // ﾟ
+      case 176  : send_the_dits_and_dahs(".--.-"); break;   // -
+      case 164  : send_the_dits_and_dahs(".-.-.-"); break;  // ､
+      case 161  : send_the_dits_and_dahs(".-.-.."); break;  // ｡
+      case 162  : send_the_dits_and_dahs("-..---"); break;  // Start wabun mode "DO(ﾎﾚ)" ｢ 
+      case 163  : send_the_dits_and_dahs("...-."); break;   // Stop wabun mode "SN(ﾗﾀ)" ｣
+      case 91   : send_the_dits_and_dahs("-.--.-"); break;  // Start english in wabun_mode "KK" [
+      case 93   : send_the_dits_and_dahs(".-..-."); break;  // Stop english in wabun_mode "RR" ]
+      #endif
+
       
       case '|': 
         #if !defined(OPTION_WINKEY_DO_NOT_SEND_7C_BYTE_HALF_SPACE)

--- a/k3ng_keyer/k3ng_keyer.ino
+++ b/k3ng_keyer/k3ng_keyer.ino
@@ -15736,6 +15736,15 @@ int convert_cw_number_to_ascii (long number_in)
 
   // number_in:  1 = dit, 2 = dah, 9 = a space
 
+  #ifdef OPTION_WABUN_CODE    // Japanese text in morse code
+  static bool mode_wabun = false;
+  static bool tmp_eng = false;
+  if (mode_wabun && !tmp_eng){
+      int jis_code = convert_cw_number_to_jis(number_in);
+      if (jis_code != 0) return jis_code;
+  }
+  #endif
+    
   switch (number_in) {
     case 12: return 65; break;         // A
     case 2111: return 66; break;
@@ -15788,6 +15797,13 @@ int convert_cw_number_to_ascii (long number_in)
     case 211112: return '-'; break;
     //case 2222222: return '+'; break;
     case 9: return 32; break;       // special 9 = space
+    
+    #ifdef OPTION_WABUN_CODE
+      case 211222: mode_wabun = true;  return 162; break;    // Start wabun mode "DO(ﾎﾚ)" ｢ 
+      case 11121:  mode_wabun = false; return 163; break;    // Stop wabun mode "SN(ﾗﾀ)" ｣
+      case 212212: tmp_eng = true; return 91; break;         // Start english in wabun_mode "KK" [
+      case 121121: tmp_eng = false; return 93; break;        // Stop english in wabun_mode "RR" ]
+    #endif
 
     #ifndef OPTION_PS2_NON_ENGLISH_CHAR_LCD_DISPLAY_SUPPORT
       case 12121: return '+'; break;
@@ -15798,12 +15814,14 @@ int convert_cw_number_to_ascii (long number_in)
       #if !defined(OPTION_PROSIGN_SUPPORT)
         case 12111: return 38; break; // & // sp5iou
       #endif  
+      #ifndef OPTION_WABUN_CODE
+        case 121121: return 34; break; // " // sp5iou // Same as stop english in wabun_mode "RR" ]
+        case 212212: return 41; break; // KK (stored as ascii ) ) // sp5iou   // Same as start english in wabun_mode "KK" [
+      #endif
       case 122221: return 39; break; // ' // sp5iou
-      case 121121: return 34; break; // " // sp5iou
       case 112212: return 95; break; // _ // sp5iou
       case 212121: return 59; break; // ; // sp5iou
       case 222111: return 58; break; // : // sp5iou
-      case 212212: return 41; break; // KK (stored as ascii ) ) // sp5iou
       #if !defined(OPTION_PROSIGN_SUPPORT)
         case 111212: return 62; break; // SK (stored as ascii > ) // sp5iou
       #endif
@@ -15815,14 +15833,16 @@ int convert_cw_number_to_ascii (long number_in)
       #if !defined(OPTION_NON_ENGLISH_EXTENSIONS)
         case 1212:   return PROSIGN_AA; break;
       #endif
+      #ifndef OPTION_WABUN_CODE
+        case 211222:   return PROSIGN_NJ; break;  // Same as start wabun  ｢ ﾎﾚ
+        case 11121:    return PROSIGN_SN; break;  // Same as stop wabun  ｣ ﾗﾀ
+      #endif
       case 12111:    return PROSIGN_AS; break;
       case 2111212:  return PROSIGN_BK; break;
       case 21211211: return PROSIGN_CL; break;
       case 21212:    return PROSIGN_CT; break;
       case 21221:    return PROSIGN_KN; break;
-      case 211222:   return PROSIGN_NJ; break;
       case 111212:   return PROSIGN_SK; break;
-      case 11121:    return PROSIGN_SN; break;
       case 11111111: return PROSIGN_HH; break;  // iz0rus
     #else //OPTION_PROSIGN_SUPPORT
       case 21221: return 40; break; // (KN store as ascii ( ) //sp5iou //aaaaaaa
@@ -15859,6 +15879,67 @@ int convert_cw_number_to_ascii (long number_in)
   }
 
 }
+
+#ifdef OPTION_WABUN_CODE
+int convert_cw_number_to_jis(long number_in){
+  switch(number_in){
+    case 22122: return 177; break;  // ｱ
+    case 12: return 178; break;
+    case 112: return 179; break;
+    case 21222: return 180; break;
+    case 12111: return 181; break;
+    case 1211: return 182; break;
+    case 21211: return 183; break;
+    case 1112: return 184; break;
+    case 2122: return 185; break;
+    case 2222: return 186; break;
+    case 21212: return 187; break;
+    case 22121: return 188; break;
+    case 22212: return 189; break;
+    case 12221: return 190; break;
+    case 2221: return 191; break;
+    case 21: return 192; break;
+    case 1121: return 193; break;
+    case 1221: return 194; break;
+    case 12122: return 195; break;
+    case 11211: return 196; break;
+    case 121: return 197; break;
+    case 2121: return 198; break;
+    case 1111: return 199; break;
+    case 2212: return 200; break;
+    case 1122: return 201; break;
+    case 2111: return 202; break;
+    case 22112: return 203; break;
+    case 2211: return 204; break;
+    case 1: return 205; break;
+    case 211: return 206; break;
+    case 2112: return 207; break;
+    case 11212: return 208; break;
+    case 2: return 209; break;
+    case 21112: return 210; break;
+    case 21121: return 211; break;
+    case 122: return 212; break;
+    case 21122: return 213; break;
+    case 22: return 214; break;
+    case 111: return 215; break;
+    case 221: return 216; break;
+    case 21221: return 217; break;
+    case 222: return 218; break;
+    case 1212: return 219; break;
+    case 212: return 220; break;    // ﾜ
+    case 1222: return 166; break;   // ｦ
+    case 12121: return 221; break;  // ﾝ
+    case 11: return 222; break;     // ﾞ
+    case 11221: return 223; break;  // ﾟ
+    case 12212: return 176; break;  // -
+    case 121212: return 164; break; // ､
+    case 121211: return 161; break; // ｡
+    case 12112 : return 178; break; // ヰ→ｲ
+    case 12211 : return 180; break; // ヱ→ｴ
+    default : return 0 ;break;
+  }
+}
+#endif
 
 //---------------------------------------------------------------------
 #ifdef DEBUG_MEMORYCHECK

--- a/k3ng_keyer/keyer_features_and_options.h
+++ b/k3ng_keyer/keyer_features_and_options.h
@@ -130,3 +130,5 @@
 
 //Added in version 2020.07.04.01
 //#define OPTION_WINKEY_PROSIGN_COMPATIBILITY  // Additional character mappings to support K1EL Winkey emulation prosigns
+
+// #define OPTION_WABUN_CODE // Japanese text in Morse code

--- a/k3ng_keyer/keyer_features_and_options_fk_10.h
+++ b/k3ng_keyer/keyer_features_and_options_fk_10.h
@@ -143,3 +143,5 @@
 
 //Added in version 2020.07.04.01
 //#define OPTION_WINKEY_PROSIGN_COMPATIBILITY  // Additional character mappings to support K1EL Winkey emulation prosigns
+
+// #define OPTION_WABUN_CODE // Japanese text in Morse code

--- a/k3ng_keyer/keyer_features_and_options_fk_11.h
+++ b/k3ng_keyer/keyer_features_and_options_fk_11.h
@@ -130,3 +130,5 @@
 
 //Added in version 2020.07.04.01
 //#define OPTION_WINKEY_PROSIGN_COMPATIBILITY  // Additional character mappings to support K1EL Winkey emulation prosigns
+
+// #define OPTION_WABUN_CODE // Japanese text in Morse code

--- a/k3ng_keyer/keyer_features_and_options_generic_STM32F103C.h
+++ b/k3ng_keyer/keyer_features_and_options_generic_STM32F103C.h
@@ -130,3 +130,5 @@ Generic STM32F103C "Blue Pill"
 
 //Added in version 2020.07.04.01
 //#define OPTION_WINKEY_PROSIGN_COMPATIBILITY  // Additional character mappings to support K1EL Winkey emulation prosigns
+
+// #define OPTION_WABUN_CODE // Japanese text in Morse code

--- a/k3ng_keyer/keyer_features_and_options_iz3gme.h
+++ b/k3ng_keyer/keyer_features_and_options_iz3gme.h
@@ -126,3 +126,5 @@
 
 //Added in version 2020.07.04.01
 //#define OPTION_WINKEY_PROSIGN_COMPATIBILITY  // Additional character mappings to support K1EL Winkey emulation prosigns
+
+// #define OPTION_WABUN_CODE // Japanese text in Morse code

--- a/k3ng_keyer/keyer_features_and_options_k5bcq.h
+++ b/k3ng_keyer/keyer_features_and_options_k5bcq.h
@@ -125,3 +125,5 @@
 
 //Added in version 2020.07.04.01
 //#define OPTION_WINKEY_PROSIGN_COMPATIBILITY  // Additional character mappings to support K1EL Winkey emulation prosigns
+
+// #define OPTION_WABUN_CODE // Japanese text in Morse code

--- a/k3ng_keyer/keyer_features_and_options_maple_mini.h
+++ b/k3ng_keyer/keyer_features_and_options_maple_mini.h
@@ -138,3 +138,5 @@
 
 //Added in version 2020.07.04.01
 //#define OPTION_WINKEY_PROSIGN_COMPATIBILITY  // Additional character mappings to support K1EL Winkey emulation prosigns
+
+// #define OPTION_WABUN_CODE // Japanese text in Morse code

--- a/k3ng_keyer/keyer_features_and_options_megakeyer.h
+++ b/k3ng_keyer/keyer_features_and_options_megakeyer.h
@@ -130,3 +130,5 @@
 
 //Added in version 2020.07.04.01
 //#define OPTION_WINKEY_PROSIGN_COMPATIBILITY  // Additional character mappings to support K1EL Winkey emulation prosigns
+
+// #define OPTION_WABUN_CODE // Japanese text in Morse code

--- a/k3ng_keyer/keyer_features_and_options_mortty.h
+++ b/k3ng_keyer/keyer_features_and_options_mortty.h
@@ -117,3 +117,5 @@
 
 //Added in version 2020.07.04.01
 //#define OPTION_WINKEY_PROSIGN_COMPATIBILITY  // Additional character mappings to support K1EL Winkey emulation prosigns
+
+// #define OPTION_WABUN_CODE // Japanese text in Morse code

--- a/k3ng_keyer/keyer_features_and_options_mortty_regular.h
+++ b/k3ng_keyer/keyer_features_and_options_mortty_regular.h
@@ -114,3 +114,5 @@
 
 //Added in version 2020.07.04.01
 //#define OPTION_WINKEY_PROSIGN_COMPATIBILITY  // Additional character mappings to support K1EL Winkey emulation prosigns
+
+// #define OPTION_WABUN_CODE // Japanese text in Morse code

--- a/k3ng_keyer/keyer_features_and_options_mortty_regular_with_potentiometer.h
+++ b/k3ng_keyer/keyer_features_and_options_mortty_regular_with_potentiometer.h
@@ -114,3 +114,5 @@
 
 //Added in version 2020.07.04.01
 //#define OPTION_WINKEY_PROSIGN_COMPATIBILITY  // Additional character mappings to support K1EL Winkey emulation prosigns
+
+// #define OPTION_WABUN_CODE // Japanese text in Morse code

--- a/k3ng_keyer/keyer_features_and_options_mortty_so2r.h
+++ b/k3ng_keyer/keyer_features_and_options_mortty_so2r.h
@@ -114,3 +114,5 @@
 
 //Added in version 2020.07.04.01
 //#define OPTION_WINKEY_PROSIGN_COMPATIBILITY  // Additional character mappings to support K1EL Winkey emulation prosigns
+
+// #define OPTION_WABUN_CODE // Japanese text in Morse code

--- a/k3ng_keyer/keyer_features_and_options_mortty_so2r_with_potentiometer.h
+++ b/k3ng_keyer/keyer_features_and_options_mortty_so2r_with_potentiometer.h
@@ -115,3 +115,5 @@
 
 //Added in version 2020.07.04.01
 //#define OPTION_WINKEY_PROSIGN_COMPATIBILITY  // Additional character mappings to support K1EL Winkey emulation prosigns
+
+// #define OPTION_WABUN_CODE // Japanese text in Morse code

--- a/k3ng_keyer/keyer_features_and_options_nanokeyer_rev_b.h
+++ b/k3ng_keyer/keyer_features_and_options_nanokeyer_rev_b.h
@@ -108,3 +108,5 @@
 
 //Added in version 2020.07.04.01
 //#define OPTION_WINKEY_PROSIGN_COMPATIBILITY  // Additional character mappings to support K1EL Winkey emulation prosigns
+
+// #define OPTION_WABUN_CODE // Japanese text in Morse code

--- a/k3ng_keyer/keyer_features_and_options_nanokeyer_rev_d.h
+++ b/k3ng_keyer/keyer_features_and_options_nanokeyer_rev_d.h
@@ -108,3 +108,4 @@
 //Added in version 2020.07.04.01
 //#define OPTION_WINKEY_PROSIGN_COMPATIBILITY  // Additional character mappings to support K1EL Winkey emulation prosigns
 
+// #define OPTION_WABUN_CODE // Japanese text in Morse code

--- a/k3ng_keyer/keyer_features_and_options_open_interface.h
+++ b/k3ng_keyer/keyer_features_and_options_open_interface.h
@@ -112,3 +112,5 @@
 
 //Added in version 2020.07.04.01
 //#define OPTION_WINKEY_PROSIGN_COMPATIBILITY  // Additional character mappings to support K1EL Winkey emulation prosigns
+
+// #define OPTION_WABUN_CODE // Japanese text in Morse code

--- a/k3ng_keyer/keyer_features_and_options_opencwkeyer_mk2.h
+++ b/k3ng_keyer/keyer_features_and_options_opencwkeyer_mk2.h
@@ -126,3 +126,5 @@
 
 //Added in version 2020.07.04.01
 //#define OPTION_WINKEY_PROSIGN_COMPATIBILITY  // Additional character mappings to support K1EL Winkey emulation prosigns
+
+// #define OPTION_WABUN_CODE // Japanese text in Morse code

--- a/k3ng_keyer/keyer_features_and_options_test.h
+++ b/k3ng_keyer/keyer_features_and_options_test.h
@@ -157,6 +157,7 @@
 //Added in version 2020.07.04.01
 //#define OPTION_WINKEY_PROSIGN_COMPATIBILITY  // Additional character mappings to support K1EL Winkey emulation prosigns
 
+// #define OPTION_WABUN_CODE // Japanese text in Morse code
 
 #endif
 
@@ -182,3 +183,4 @@
 //    ##    ##             ##    ##    
 //    ##    ##       ##    ##    ##    
 //    ##    ########  ######     ##    
+

--- a/k3ng_keyer/keyer_features_and_options_test_everything.h
+++ b/k3ng_keyer/keyer_features_and_options_test_everything.h
@@ -140,3 +140,5 @@
 
 //Added in version 2020.07.04.01
 #define OPTION_WINKEY_PROSIGN_COMPATIBILITY  // Additional character mappings to support K1EL Winkey emulation prosigns
+
+// #define OPTION_WABUN_CODE // Japanese text in Morse code

--- a/k3ng_keyer/keyer_features_and_options_tinykeyer.h
+++ b/k3ng_keyer/keyer_features_and_options_tinykeyer.h
@@ -90,3 +90,5 @@
 
 //Added in version 2020.07.04.01
 //#define OPTION_WINKEY_PROSIGN_COMPATIBILITY  // Additional character mappings to support K1EL Winkey emulation prosigns
+
+// #define OPTION_WABUN_CODE // Japanese text in Morse code

--- a/k3ng_keyer/keyer_features_and_options_yaacwk.h
+++ b/k3ng_keyer/keyer_features_and_options_yaacwk.h
@@ -121,3 +121,5 @@
 
 //Added in version 2020.07.04.01
 //#define OPTION_WINKEY_PROSIGN_COMPATIBILITY  // Additional character mappings to support K1EL Winkey emulation prosigns
+
+// #define OPTION_WABUN_CODE // Japanese text in Morse code

--- a/k3ng_keyer/keyer_features_and_options_yccc_so2r_mini.h
+++ b/k3ng_keyer/keyer_features_and_options_yccc_so2r_mini.h
@@ -135,3 +135,5 @@
 
 //Added in version 2020.07.04.01
 //#define OPTION_WINKEY_PROSIGN_COMPATIBILITY  // Additional character mappings to support K1EL Winkey emulation prosigns
+
+// #define OPTION_WABUN_CODE // Japanese text in Morse code


### PR DESCRIPTION
I implemented "OPTION_WABUN_CODE" (Japanese text in morse code)
https://en.wikipedia.org/wiki/Wabun_code

The wabun code is switched from the English code with prosign "DO", and returns to the English code with "SN".
To insert the alphabet in wabun code, put that part in the prosign "KK" and "RR".

I tested with my Generic STM32F103C board and 2004 character (HD44780 compatible) LCD, it works fine.