### PR TITLE
Add FEATURE_LCD_BACKLIGHT_AUTO_DIM dims LCD and/or Power LED after x …

### DIFF
--- a/k3ng_keyer/keyer_debug.h
+++ b/k3ng_keyer/keyer_debug.h
@@ -23,6 +23,7 @@
 // #define DEBUG_CW_DECODER_WPM
 // #define DEBUG_SERIAL_SEND_CW_CALLOUT
 // #define DEBUG_SLEEP
+// #define DEBUG_BACKLIGHT
 // #define DEBUG_BUTTON_ARRAY
 // #define DEBUG_USB
 // #define DEBUG_USB_KEYBOARD

--- a/k3ng_keyer/keyer_features_and_options.h
+++ b/k3ng_keyer/keyer_features_and_options.h
@@ -36,6 +36,7 @@
 // #define FEATURE_LCD_HD44780
 // #define FEATURE_CW_DECODER              // https://github.com/k3ng/k3ng_cw_keyer/wiki/385-Feature:-CW-Decoder 
 // #define FEATURE_SLEEP                   // go to sleep after x minutes to conserve battery power (not compatible with Arduino DUE, may have mixed results with Mega and Mega ADK)
+// #define FEATURE_LCD_BACKLIGHT_AUTO_DIM  // turn off LCD backlight and/or dim Power Indicator LED after x minutes (LED requires a PWM pin)
 // #define FEATURE_ROTARY_ENCODER          // rotary encoder speed control
 // #define FEATURE_CMOS_SUPER_KEYER_IAMBIC_B_TIMING
 // #define FEATURE_USB_MOUSE               // Uncomment three lines in k3ng_keyer.ino (search for note_usb_uncomment_lines)

--- a/k3ng_keyer/keyer_features_and_options_fk_10.h
+++ b/k3ng_keyer/keyer_features_and_options_fk_10.h
@@ -52,6 +52,7 @@
 // #define FEATURE_LCD_I2C_FDEBRABANDER //https://github.com/fdebrabander/Arduino-LiquidCrystal-I2C-library
 #define FEATURE_CW_DECODER              // https://github.com/k3ng/k3ng_cw_keyer/wiki/385-Feature:-CW-Decoder 
 // #define FEATURE_SLEEP                   // go to sleep after x minutes to conserve battery power (not compatible with Arduino DUE, may have mixed results with Mega and Mega ADK)
+// #define FEATURE_LCD_BACKLIGHT_AUTO_DIM  // turn off LCD backlight and/or dim Power Indicator LED after x minutes (LED requires a PWM pin)
 #define FEATURE_ROTARY_ENCODER          // rotary encoder speed control
 #define FEATURE_CMOS_SUPER_KEYER_IAMBIC_B_TIMING
 #define FEATURE_USB_MOUSE               // Uncomment three lines in k3ng_keyer.ino (search for note_usb_uncomment_lines)

--- a/k3ng_keyer/keyer_features_and_options_fk_11.h
+++ b/k3ng_keyer/keyer_features_and_options_fk_11.h
@@ -37,6 +37,7 @@
 // #define FEATURE_LCD_HD44780
 #define FEATURE_CW_DECODER              // https://github.com/k3ng/k3ng_cw_keyer/wiki/385-Feature:-CW-Decoder 
 // #define FEATURE_SLEEP                   // go to sleep after x minutes to conserve battery power (not compatible with Arduino DUE, may have mixed results with Mega and Mega ADK)
+// #define FEATURE_LCD_BACKLIGHT_AUTO_DIM  // turn off LCD backlight and/or dim Power Indicator LED after x minutes (LED requires a PWM pin)
 #define FEATURE_ROTARY_ENCODER          // rotary encoder speed control
 #define FEATURE_CMOS_SUPER_KEYER_IAMBIC_B_TIMING
 #define FEATURE_USB_MOUSE               // Uncomment three lines in k3ng_keyer.ino (search for note_usb_uncomment_lines)

--- a/k3ng_keyer/keyer_features_and_options_generic_STM32F103C.h
+++ b/k3ng_keyer/keyer_features_and_options_generic_STM32F103C.h
@@ -41,6 +41,7 @@ Generic STM32F103C "Blue Pill"
 // #define FEATURE_LCD_I2C_FDEBRABANDER //https://github.com/fdebrabander/Arduino-LiquidCrystal-I2C-library
 // #define FEATURE_CW_DECODER              // https://github.com/k3ng/k3ng_cw_keyer/wiki/385-Feature:-CW-Decoder 
 // #define FEATURE_SLEEP                   // go to sleep after x minutes to conserve battery power (not compatible with Arduino DUE, may have mixed results with Mega and Mega ADK)
+// #define FEATURE_LCD_BACKLIGHT_AUTO_DIM  // turn off LCD backlight and/or dim Power Indicator LED after x minutes (LED requires a PWM pin)
 #define FEATURE_ROTARY_ENCODER          // rotary encoder speed control
 // #define FEATURE_CMOS_SUPER_KEYER_IAMBIC_B_TIMING
 // #define FEATURE_USB_MOUSE               // Uncomment three lines in k3ng_keyer.ino (search for note_usb_uncomment_lines)

--- a/k3ng_keyer/keyer_features_and_options_iz3gme.h
+++ b/k3ng_keyer/keyer_features_and_options_iz3gme.h
@@ -36,6 +36,7 @@
 // #define FEATURE_LCD_HD44780
 // #define FEATURE_CW_DECODER              // https://github.com/k3ng/k3ng_cw_keyer/wiki/385-Feature:-CW-Decoder 
 // #define FEATURE_SLEEP                   // go to sleep after x minutes to conserve battery power (not compatible with Arduino DUE, may have mixed results with Mega and Mega ADK)
+// #define FEATURE_LCD_BACKLIGHT_AUTO_DIM  // turn off LCD backlight and/or dim Power Indicator LED after x minutes (LED requires a PWM pin)
 // #define FEATURE_ROTARY_ENCODER          // rotary encoder speed control
 // #define FEATURE_CMOS_SUPER_KEYER_IAMBIC_B_TIMING
 // #define FEATURE_USB_MOUSE               // Uncomment three lines in k3ng_keyer.ino (search for note_usb_uncomment_lines)

--- a/k3ng_keyer/keyer_features_and_options_k5bcq.h
+++ b/k3ng_keyer/keyer_features_and_options_k5bcq.h
@@ -34,6 +34,7 @@
 // #define FEATURE_LCD_I2C_FDEBRABANDER //https://github.com/fdebrabander/Arduino-LiquidCrystal-I2C-library
 #define FEATURE_CW_DECODER              // https://github.com/k3ng/k3ng_cw_keyer/wiki/385-Feature:-CW-Decoder 
 // #define FEATURE_SLEEP                   // go to sleep after x minutes to conserve battery power (not compatible with Arduino DUE, may have mixed results with Mega and Mega ADK)
+// #define FEATURE_LCD_BACKLIGHT_AUTO_DIM  // turn off LCD backlight and/or dim Power Indicator LED after x minutes (LED requires a PWM pin)
 #define FEATURE_ROTARY_ENCODER          // rotary encoder speed control
 // #define FEATURE_CMOS_SUPER_KEYER_IAMBIC_B_TIMING
 // #define FEATURE_USB_MOUSE               // Uncomment three lines in k3ng_keyer.ino (search for note_usb_uncomment_lines)

--- a/k3ng_keyer/keyer_features_and_options_maple_mini.h
+++ b/k3ng_keyer/keyer_features_and_options_maple_mini.h
@@ -48,6 +48,7 @@
 // #define FEATURE_LCD_I2C_FDEBRABANDER //https://github.com/fdebrabander/Arduino-LiquidCrystal-I2C-library
 // #define FEATURE_CW_DECODER              // https://github.com/k3ng/k3ng_cw_keyer/wiki/385-Feature:-CW-Decoder 
 // #define FEATURE_SLEEP                   // go to sleep after x minutes to conserve battery power (not compatible with Arduino DUE, may have mixed results with Mega and Mega ADK)
+// #define FEATURE_LCD_BACKLIGHT_AUTO_DIM  // turn off LCD backlight and/or dim Power Indicator LED after x minutes (LED requires a PWM pin)
 // #define FEATURE_ROTARY_ENCODER          // rotary encoder speed control
 // #define FEATURE_CMOS_SUPER_KEYER_IAMBIC_B_TIMING
 // #define FEATURE_USB_MOUSE               // Uncomment three lines in k3ng_keyer.ino (search for note_usb_uncomment_lines)

--- a/k3ng_keyer/keyer_features_and_options_megakeyer.h
+++ b/k3ng_keyer/keyer_features_and_options_megakeyer.h
@@ -40,6 +40,7 @@
 // #define FEATURE_LCD_I2C_FDEBRABANDER //https://github.com/fdebrabander/Arduino-LiquidCrystal-I2C-library
 // #define FEATURE_CW_DECODER              // https://github.com/k3ng/k3ng_cw_keyer/wiki/385-Feature:-CW-Decoder 
 // #define FEATURE_SLEEP                   // go to sleep after x minutes to conserve battery power (not compatible with Arduino DUE, may have mixed results with Mega and Mega ADK)
+// #define FEATURE_LCD_BACKLIGHT_AUTO_DIM  // turn off LCD backlight and/or dim Power Indicator LED after x minutes (LED requires a PWM pin)
 #define FEATURE_ROTARY_ENCODER          // rotary encoder speed control
 #define FEATURE_CMOS_SUPER_KEYER_IAMBIC_B_TIMING
 // #define FEATURE_USB_MOUSE               // Uncomment three lines in k3ng_keyer.ino (search for note_usb_uncomment_lines)

--- a/k3ng_keyer/keyer_features_and_options_mortty.h
+++ b/k3ng_keyer/keyer_features_and_options_mortty.h
@@ -32,6 +32,7 @@
 // #define FEATURE_LCD_I2C_FDEBRABANDER //https://github.com/fdebrabander/Arduino-LiquidCrystal-I2C-library
 // #define FEATURE_CW_DECODER              // https://github.com/k3ng/k3ng_cw_keyer/wiki/385-Feature:-CW-Decoder 
 // #define FEATURE_SLEEP                   // go to sleep after x minutes to conserve battery power (not compatible with Arduino DUE, may have mixed results with Mega and Mega ADK)
+// #define FEATURE_LCD_BACKLIGHT_AUTO_DIM  // turn off LCD backlight and/or dim Power Indicator LED after x minutes (LED requires a PWM pin)
 // #define FEATURE_ROTARY_ENCODER          // rotary encoder speed control
 // #define FEATURE_CMOS_SUPER_KEYER_IAMBIC_B_TIMING
 // #define FEATURE_USB_MOUSE               // Uncomment three lines in k3ng_keyer.ino (search for note_usb_uncomment_lines)

--- a/k3ng_keyer/keyer_features_and_options_mortty_regular.h
+++ b/k3ng_keyer/keyer_features_and_options_mortty_regular.h
@@ -32,6 +32,7 @@
 // #define FEATURE_LCD_I2C_FDEBRABANDER //https://github.com/fdebrabander/Arduino-LiquidCrystal-I2C-library
 // #define FEATURE_CW_DECODER              // https://github.com/k3ng/k3ng_cw_keyer/wiki/385-Feature:-CW-Decoder 
 // #define FEATURE_SLEEP                   // go to sleep after x minutes to conserve battery power (not compatible with Arduino DUE, may have mixed results with Mega and Mega ADK)
+// #define FEATURE_LCD_BACKLIGHT_AUTO_DIM  // turn off LCD backlight and/or dim Power Indicator LED after x minutes (LED requires a PWM pin)
 // #define FEATURE_ROTARY_ENCODER          // rotary encoder speed control
 // #define FEATURE_CMOS_SUPER_KEYER_IAMBIC_B_TIMING
 // #define FEATURE_USB_MOUSE               // Uncomment three lines in k3ng_keyer.ino (search for note_usb_uncomment_lines)

--- a/k3ng_keyer/keyer_features_and_options_mortty_regular_with_potentiometer.h
+++ b/k3ng_keyer/keyer_features_and_options_mortty_regular_with_potentiometer.h
@@ -32,6 +32,7 @@
 // #define FEATURE_LCD_I2C_FDEBRABANDER //https://github.com/fdebrabander/Arduino-LiquidCrystal-I2C-library
 // #define FEATURE_CW_DECODER              // https://github.com/k3ng/k3ng_cw_keyer/wiki/385-Feature:-CW-Decoder 
 // #define FEATURE_SLEEP                   // go to sleep after x minutes to conserve battery power (not compatible with Arduino DUE, may have mixed results with Mega and Mega ADK)
+// #define FEATURE_LCD_BACKLIGHT_AUTO_DIM  // turn off LCD backlight and/or dim Power Indicator LED after x minutes (LED requires a PWM pin)
 // #define FEATURE_ROTARY_ENCODER          // rotary encoder speed control
 // #define FEATURE_CMOS_SUPER_KEYER_IAMBIC_B_TIMING
 // #define FEATURE_USB_MOUSE               // Uncomment three lines in k3ng_keyer.ino (search for note_usb_uncomment_lines)

--- a/k3ng_keyer/keyer_features_and_options_mortty_so2r.h
+++ b/k3ng_keyer/keyer_features_and_options_mortty_so2r.h
@@ -32,6 +32,7 @@
 // #define FEATURE_LCD_I2C_FDEBRABANDER //https://github.com/fdebrabander/Arduino-LiquidCrystal-I2C-library
 // #define FEATURE_CW_DECODER              // https://github.com/k3ng/k3ng_cw_keyer/wiki/385-Feature:-CW-Decoder 
 // #define FEATURE_SLEEP                   // go to sleep after x minutes to conserve battery power (not compatible with Arduino DUE, may have mixed results with Mega and Mega ADK)
+// #define FEATURE_LCD_BACKLIGHT_AUTO_DIM  // turn off LCD backlight and/or dim Power Indicator LED after x minutes (LED requires a PWM pin)
 // #define FEATURE_ROTARY_ENCODER          // rotary encoder speed control
 // #define FEATURE_CMOS_SUPER_KEYER_IAMBIC_B_TIMING
 // #define FEATURE_USB_MOUSE               // Uncomment three lines in k3ng_keyer.ino (search for note_usb_uncomment_lines)

--- a/k3ng_keyer/keyer_features_and_options_mortty_so2r_with_potentiometer.h
+++ b/k3ng_keyer/keyer_features_and_options_mortty_so2r_with_potentiometer.h
@@ -31,6 +31,7 @@
 // #define FEATURE_LCD_I2C_FDEBRABANDER //https://github.com/fdebrabander/Arduino-LiquidCrystal-I2C-library
 // #define FEATURE_CW_DECODER              // https://github.com/k3ng/k3ng_cw_keyer/wiki/385-Feature:-CW-Decoder 
 // #define FEATURE_SLEEP                   // go to sleep after x minutes to conserve battery power (not compatible with Arduino DUE, may have mixed results with Mega and Mega ADK)
+// #define FEATURE_LCD_BACKLIGHT_AUTO_DIM  // turn off LCD backlight and/or dim Power Indicator LED after x minutes (LED requires a PWM pin)
 // #define FEATURE_ROTARY_ENCODER          // rotary encoder speed control
 // #define FEATURE_CMOS_SUPER_KEYER_IAMBIC_B_TIMING
 // #define FEATURE_USB_MOUSE               // Uncomment three lines in k3ng_keyer.ino (search for note_usb_uncomment_lines)

--- a/k3ng_keyer/keyer_features_and_options_nanokeyer_rev_b.h
+++ b/k3ng_keyer/keyer_features_and_options_nanokeyer_rev_b.h
@@ -27,6 +27,7 @@
 //#define FEATURE_LCD_I2C_FDEBRABANDER //https://github.com/fdebrabander/Arduino-LiquidCrystal-I2C-library
 // #define FEATURE_CW_DECODER              // https://github.com/k3ng/k3ng_cw_keyer/wiki/385-Feature:-CW-Decoder 
 //#define FEATURE_SLEEP                   // go to sleep after x minutes to conserve battery power (not compatible with Arduino DUE, may have mixed results with Mega and Mega ADK)
+//#define FEATURE_LCD_BACKLIGHT_AUTO_DIM  // turn off LCD backlight and/or dim Power Indicator LED after x minutes (LED requires a PWM pin)
 //#define FEATURE_ROTARY_ENCODER          // rotary encoder speed control
 //#define FEATURE_CMOS_SUPER_KEYER_IAMBIC_B_TIMING
 //#define FEATURE_USB_MOUSE               // Uncomment three lines in k3ng_keyer.ino (search for note_usb_uncomment_lines)

--- a/k3ng_keyer/keyer_features_and_options_nanokeyer_rev_d.h
+++ b/k3ng_keyer/keyer_features_and_options_nanokeyer_rev_d.h
@@ -26,6 +26,7 @@
 //#define FEATURE_LCD_I2C_FDEBRABANDER //https://github.com/fdebrabander/Arduino-LiquidCrystal-I2C-library
 // #define FEATURE_CW_DECODER              // https://github.com/k3ng/k3ng_cw_keyer/wiki/385-Feature:-CW-Decoder 
 //#define FEATURE_SLEEP                   // go to sleep after x minutes to conserve battery power
+//#define FEATURE_LCD_BACKLIGHT_AUTO_DIM  // turn off LCD backlight and/or dim Power Indicator LED after x minutes (LED requires a PWM pin)
 //#define FEATURE_ROTARY_ENCODER          // rotary encoder speed control
 //#define FEATURE_CMOS_SUPER_KEYER_IAMBIC_B_TIMING
 //#define FEATURE_USB_MOUSE

--- a/k3ng_keyer/keyer_features_and_options_open_interface.h
+++ b/k3ng_keyer/keyer_features_and_options_open_interface.h
@@ -30,6 +30,7 @@
 // #define FEATURE_LCD_I2C_FDEBRABANDER //https://github.com/fdebrabander/Arduino-LiquidCrystal-I2C-library
 // #define FEATURE_CW_DECODER              // https://github.com/k3ng/k3ng_cw_keyer/wiki/385-Feature:-CW-Decoder 
 //#define FEATURE_SLEEP                   // go to sleep after x minutes to conserve battery power
+//#define FEATURE_LCD_BACKLIGHT_AUTO_DIM  // turn off LCD backlight and/or dim Power Indicator LED after x minutes (LED requires a PWM pin)
 //#define FEATURE_ROTARY_ENCODER          // rotary encoder speed control
 #define FEATURE_CMOS_SUPER_KEYER_IAMBIC_B_TIMING
 //#define FEATURE_USB_MOUSE                // Uncomment three lines in k3ng_keyer.ino (search for note_usb_uncomment_lines)

--- a/k3ng_keyer/keyer_features_and_options_opencwkeyer_mk2.h
+++ b/k3ng_keyer/keyer_features_and_options_opencwkeyer_mk2.h
@@ -36,6 +36,7 @@
 // #define FEATURE_LCD_HD44780
 // #define FEATURE_CW_DECODER              // https://github.com/k3ng/k3ng_cw_keyer/wiki/385-Feature:-CW-Decoder 
 // #define FEATURE_SLEEP                   // go to sleep after x minutes to conserve battery power (not compatible with Arduino DUE, may have mixed results with Mega and Mega ADK)
+// #define FEATURE_LCD_BACKLIGHT_AUTO_DIM  // turn off LCD backlight and/or dim Power Indicator LED after x minutes (LED requires a PWM pin)
 // #define FEATURE_ROTARY_ENCODER          // rotary encoder speed control
 // #define FEATURE_CMOS_SUPER_KEYER_IAMBIC_B_TIMING
 // #define FEATURE_USB_MOUSE               // Uncomment three lines in k3ng_keyer.ino (search for note_usb_uncomment_lines)

--- a/k3ng_keyer/keyer_features_and_options_test.h
+++ b/k3ng_keyer/keyer_features_and_options_test.h
@@ -46,6 +46,7 @@
 // #define FEATURE_LCD_I2C_FDEBRABANDER //https://github.com/fdebrabander/Arduino-LiquidCrystal-I2C-library
 // #define FEATURE_CW_DECODER              // https://github.com/k3ng/k3ng_cw_keyer/wiki/385-Feature:-CW-Decoder 
 // #define FEATURE_SLEEP                   // go to sleep after x minutes to conserve battery power (not compatible with Arduino DUE, may have mixed results with Mega and Mega ADK)
+// #define FEATURE_LCD_BACKLIGHT_AUTO_DIM  // turn off LCD backlight and/or dim Power Indicator LED after x minutes (LED requires a PWM pin)
 // #define FEATURE_ROTARY_ENCODER          // rotary encoder speed control
 // #define FEATURE_CMOS_SUPER_KEYER_IAMBIC_B_TIMING
 // #define FEATURE_USB_MOUSE               // Uncomment three lines in k3ng_keyer.ino (search for note_usb_uncomment_lines)

--- a/k3ng_keyer/keyer_features_and_options_test_everything.h
+++ b/k3ng_keyer/keyer_features_and_options_test_everything.h
@@ -32,6 +32,7 @@
 // #define FEATURE_LCD_I2C_FDEBRABANDER //https://github.com/fdebrabander/Arduino-LiquidCrystal-I2C-library
 #define FEATURE_CW_DECODER              // https://github.com/k3ng/k3ng_cw_keyer/wiki/385-Feature:-CW-Decoder 
 #define FEATURE_SLEEP                   // go to sleep after x minutes to conserve battery power (not compatible with Arduino DUE, may have mixed results with Mega and Mega ADK)
+#define FEATURE_LCD_BACKLIGHT_AUTO_DIM  // turn off LCD backlight and/or dim Power Indicator LED after x minutes (LED requires a PWM pin)
 #define FEATURE_ROTARY_ENCODER          // rotary encoder speed control
 #define FEATURE_CMOS_SUPER_KEYER_IAMBIC_B_TIMING
 // #define FEATURE_USB_MOUSE               // Uncomment three lines in k3ng_keyer.ino (search for note_usb_uncomment_lines)

--- a/k3ng_keyer/keyer_features_and_options_tinykeyer.h
+++ b/k3ng_keyer/keyer_features_and_options_tinykeyer.h
@@ -19,6 +19,7 @@
 //#define FEATURE_FARNSWORTH
 //#define FEATURE_DL2SBA_BANKSWITCH       // Switch memory banks feature as described here: http://dl2sba.com/index.php?option=com_content&view=article&id=131:nanokeyer&catid=15:shack&Itemid=27#english
 //#define FEATURE_SLEEP                   // go to sleep after x minutes to conserve battery power
+//#define FEATURE_LCD_BACKLIGHT_AUTO_DIM  // turn off LCD backlight and/or dim Power Indicator LED after x minutes (LED requires a PWM pin)
 #define FEATURE_ROTARY_ENCODER            // rotary encoder speed control
 //#define FEATURE_CMOS_SUPER_KEYER_IAMBIC_B_TIMING
 //#define FEATURE_DIT_DAH_BUFFER_CONTROL

--- a/k3ng_keyer/keyer_features_and_options_yaacwk.h
+++ b/k3ng_keyer/keyer_features_and_options_yaacwk.h
@@ -31,6 +31,7 @@
 //#define FEATURE_LCD_FABO_PCF8574  // https://github.com/FaBoPlatform/FaBoLCD-PCF8574-Library
 #define FEATURE_CW_DECODER
 //#define FEATURE_SLEEP                   // go to sleep after x minutes to conserve battery power
+//#define FEATURE_LCD_BACKLIGHT_AUTO_DIM  // turn off LCD backlight and/or dim Power Indicator LED after x minutes (LED requires a PWM pin)
 //#define FEATURE_ROTARY_ENCODER          // rotary encoder speed control
 //#define FEATURE_CMOS_SUPER_KEYER_IAMBIC_B_TIMING
 //#define FEATURE_USB_MOUSE                // Uncomment three lines in k3ng_keyer.ino (search for note_usb_uncomment_lines)

--- a/k3ng_keyer/keyer_features_and_options_yccc_so2r_mini.h
+++ b/k3ng_keyer/keyer_features_and_options_yccc_so2r_mini.h
@@ -42,6 +42,7 @@
 // #define FEATURE_LCD_HD44780
 // #define FEATURE_CW_DECODER
 // #define FEATURE_SLEEP                   // go to sleep after x minutes to conserve battery power (not compatible with Arduino DUE, may have mixed results with Mega and Mega ADK)
+// #define FEATURE_LCD_BACKLIGHT_AUTO_DIM  // turn off LCD backlight and/or dim Power Indicator LED after x minutes (LED requires a PWM pin)
 // #define FEATURE_ROTARY_ENCODER          // rotary encoder speed control
 // #define FEATURE_CMOS_SUPER_KEYER_IAMBIC_B_TIMING
 // #define FEATURE_USB_MOUSE               // Uncomment three lines in k3ng_keyer.ino (search for note_usb_uncomment_lines)

--- a/k3ng_keyer/keyer_pin_settings.h
+++ b/k3ng_keyer/keyer_pin_settings.h
@@ -111,6 +111,10 @@ FEATURE_SIDETONE_SWITCH
   #define keyer_awake 0
 #endif
 
+#if defined(FEATURE_LCD_BACKLIGHT_AUTO_DIM)
+  #define keyer_power_led 0   // must be a PWM-capable pin
+#endif
+
 #if defined(FEATURE_CAPACITIVE_PADDLE_PINS)
   #define capactive_paddle_pin_inhibit_pin 0     // if this pin is defined and is set high, the capacitive paddle pins will switch to normal (non-capacitive) sensing mode
 #endif

--- a/k3ng_keyer/keyer_pin_settings_fk_10.h
+++ b/k3ng_keyer/keyer_pin_settings_fk_10.h
@@ -101,6 +101,10 @@
   #define keyer_awake 0
 #endif
 
+#if defined(FEATURE_LCD_BACKLIGHT_AUTO_DIM)
+  #define keyer_power_led 0   // must be a PWM-capable pin
+#endif
+
 #if defined(FEATURE_CAPACITIVE_PADDLE_PINS)
   #define capactive_paddle_pin_inhibit_pin 0     // if this pin is defined and is set high, the capacitive paddle pins will switch to normal (non-capacitive) sensing mode
 #endif

--- a/k3ng_keyer/keyer_pin_settings_fk_11.h
+++ b/k3ng_keyer/keyer_pin_settings_fk_11.h
@@ -114,6 +114,10 @@ FEATURE_SIDETONE_SWITCH
   #define keyer_awake 0
 #endif
 
+#if defined(FEATURE_LCD_BACKLIGHT_AUTO_DIM)
+  #define keyer_power_led 0   // must be a PWM-capable pin
+#endif
+
 #if defined(FEATURE_CAPACITIVE_PADDLE_PINS)
   #define capactive_paddle_pin_inhibit_pin 0     // if this pin is defined and is set high, the capacitive paddle pins will switch to normal (non-capacitive) sensing mode
 #endif

--- a/k3ng_keyer/keyer_pin_settings_generic_STM32F103C.h
+++ b/k3ng_keyer/keyer_pin_settings_generic_STM32F103C.h
@@ -119,6 +119,10 @@ FEATURE_SIDETONE_SWITCH
   #define keyer_awake 0
 #endif
 
+#if defined(FEATURE_LCD_BACKLIGHT_AUTO_DIM)
+  #define keyer_power_led 0   // must be a PWM-capable pin
+#endif
+
 #if defined(FEATURE_CAPACITIVE_PADDLE_PINS)
   #define capactive_paddle_pin_inhibit_pin 0     // if this pin is defined and is set high, the capacitive paddle pins will switch to normal (non-capacitive) sensing mode
 #endif

--- a/k3ng_keyer/keyer_pin_settings_iz3gme.h
+++ b/k3ng_keyer/keyer_pin_settings_iz3gme.h
@@ -112,6 +112,10 @@ FEATURE_SIDETONE_SWITCH
   #define keyer_awake 0
 #endif
 
+#if defined(FEATURE_LCD_BACKLIGHT_AUTO_DIM)
+  #define keyer_power_led 0   // must be a PWM-capable pin
+#endif
+
 #if defined(FEATURE_CAPACITIVE_PADDLE_PINS)
   #define capactive_paddle_pin_inhibit_pin 0     // if this pin is defined and is set high, the capacitive paddle pins will switch to normal (non-capacitive) sensing mode
 #endif

--- a/k3ng_keyer/keyer_pin_settings_k5bcq.h
+++ b/k3ng_keyer/keyer_pin_settings_k5bcq.h
@@ -112,6 +112,10 @@ FEATURE_SIDETONE_SWITCH
   #define keyer_awake 0
 #endif
 
+#if defined(FEATURE_LCD_BACKLIGHT_AUTO_DIM)
+  #define keyer_power_led 0   // must be a PWM-capable pin
+#endif
+
 #if defined(FEATURE_CAPACITIVE_PADDLE_PINS)
   #define capactive_paddle_pin_inhibit_pin 0     // if this pin is defined and is set high, the capacitive paddle pins will switch to normal (non-capacitive) sensing mode
 #endif

--- a/k3ng_keyer/keyer_pin_settings_maple_mini.h
+++ b/k3ng_keyer/keyer_pin_settings_maple_mini.h
@@ -126,6 +126,10 @@ FEATURE_SIDETONE_SWITCH
   #define keyer_awake 6
 #endif
 
+#if defined(FEATURE_LCD_BACKLIGHT_AUTO_DIM)
+  #define keyer_power_led 0   // must be a PWM-capable pin
+#endif
+
 #if defined(FEATURE_CAPACITIVE_PADDLE_PINS)
   #define capactive_paddle_pin_inhibit_pin 0     // if this pin is defined and is set high, the capacitive paddle pins will switch to normal (non-capacitive) sensing mode
 #endif

--- a/k3ng_keyer/keyer_pin_settings_megakeyer.h
+++ b/k3ng_keyer/keyer_pin_settings_megakeyer.h
@@ -112,6 +112,10 @@ FEATURE_SIDETONE_SWITCH
   #define keyer_awake 0
 #endif
 
+#if defined(FEATURE_LCD_BACKLIGHT_AUTO_DIM)
+  #define keyer_power_led 0   // must be a PWM-capable pin
+#endif
+
 #if defined(FEATURE_CAPACITIVE_PADDLE_PINS)
   #define capactive_paddle_pin_inhibit_pin 0     // if this pin is defined and is set high, the capacitive paddle pins will switch to normal (non-capacitive) sensing mode
 #endif

--- a/k3ng_keyer/keyer_pin_settings_mortty.h
+++ b/k3ng_keyer/keyer_pin_settings_mortty.h
@@ -112,6 +112,10 @@ FEATURE_SIDETONE_SWITCH
   #define keyer_awake 0
 #endif
 
+#if defined(FEATURE_LCD_BACKLIGHT_AUTO_DIM)
+  #define keyer_power_led 0   // must be a PWM-capable pin
+#endif
+
 #if defined(FEATURE_CAPACITIVE_PADDLE_PINS)
   #define capactive_paddle_pin_inhibit_pin 0     // if this pin is defined and is set high, the capacitive paddle pins will switch to normal (non-capacitive) sensing mode
 #endif

--- a/k3ng_keyer/keyer_pin_settings_mortty_regular.h
+++ b/k3ng_keyer/keyer_pin_settings_mortty_regular.h
@@ -105,6 +105,10 @@ FEATURE_SIDETONE_SWITCH
   #define keyer_awake 0
 #endif
 
+#if defined(FEATURE_LCD_BACKLIGHT_AUTO_DIM)
+  #define keyer_power_led 0   // must be a PWM-capable pin
+#endif
+
 #if defined(FEATURE_CAPACITIVE_PADDLE_PINS)
   #define capactive_paddle_pin_inhibit_pin 0     // if this pin is defined and is set high, the capacitive paddle pins will switch to normal (non-capacitive) sensing mode
 #endif

--- a/k3ng_keyer/keyer_pin_settings_mortty_regular_with_potentiometer.h
+++ b/k3ng_keyer/keyer_pin_settings_mortty_regular_with_potentiometer.h
@@ -105,6 +105,10 @@ FEATURE_SIDETONE_SWITCH
   #define keyer_awake 0
 #endif
 
+#if defined(FEATURE_LCD_BACKLIGHT_AUTO_DIM)
+  #define keyer_power_led 0   // must be a PWM-capable pin
+#endif
+
 #if defined(FEATURE_CAPACITIVE_PADDLE_PINS)
   #define capactive_paddle_pin_inhibit_pin 0     // if this pin is defined and is set high, the capacitive paddle pins will switch to normal (non-capacitive) sensing mode
 #endif

--- a/k3ng_keyer/keyer_pin_settings_mortty_so2r.h
+++ b/k3ng_keyer/keyer_pin_settings_mortty_so2r.h
@@ -105,6 +105,10 @@ FEATURE_SIDETONE_SWITCH
   #define keyer_awake 0
 #endif
 
+#if defined(FEATURE_LCD_BACKLIGHT_AUTO_DIM)
+  #define keyer_power_led 0   // must be a PWM-capable pin
+#endif
+
 #if defined(FEATURE_CAPACITIVE_PADDLE_PINS)
   #define capactive_paddle_pin_inhibit_pin 0     // if this pin is defined and is set high, the capacitive paddle pins will switch to normal (non-capacitive) sensing mode
 #endif

--- a/k3ng_keyer/keyer_pin_settings_mortty_so2r_with_potentiometer.h
+++ b/k3ng_keyer/keyer_pin_settings_mortty_so2r_with_potentiometer.h
@@ -105,6 +105,10 @@ FEATURE_SIDETONE_SWITCH
   #define keyer_awake 0
 #endif
 
+#if defined(FEATURE_LCD_BACKLIGHT_AUTO_DIM)
+  #define keyer_power_led 0   // must be a PWM-capable pin
+#endif
+
 #if defined(FEATURE_CAPACITIVE_PADDLE_PINS)
   #define capactive_paddle_pin_inhibit_pin 0     // if this pin is defined and is set high, the capacitive paddle pins will switch to normal (non-capacitive) sensing mode
 #endif

--- a/k3ng_keyer/keyer_pin_settings_nanokeyer_rev_b.h
+++ b/k3ng_keyer/keyer_pin_settings_nanokeyer_rev_b.h
@@ -36,6 +36,10 @@
   #define keyer_awake 13       // Goes active when keyer is awake, inactive when in sleep mode; change active and inactive states in keyer_settings file
 #endif
 
+#if defined(FEATURE_LCD_BACKLIGHT_AUTO_DIM)
+  #define keyer_power_led 0   // must be a PWM-capable pin
+#endif
+
 #if defined(FEATURE_CAPACITIVE_PADDLE_PINS)
   #define capactive_paddle_pin_inhibit_pin 0     // if this pin is defined and is set high, the capacitive paddle pins will switch to normal (non-capacitive) sensing mode
 #endif

--- a/k3ng_keyer/keyer_pin_settings_nanokeyer_rev_d.h
+++ b/k3ng_keyer/keyer_pin_settings_nanokeyer_rev_d.h
@@ -35,6 +35,10 @@
   #define keyer_awake 13       // Goes active when keyer is awake, inactive when in sleep mode; change active and inactive states in keyer_settings file
 #endif
 
+#if defined(FEATURE_LCD_BACKLIGHT_AUTO_DIM)
+  #define keyer_power_led 0   // must be a PWM-capable pin
+#endif
+
 #if defined(FEATURE_CAPACITIVE_PADDLE_PINS)
   #define capactive_paddle_pin_inhibit_pin 0     // if this pin is defined and is set high, the capacitive paddle pins will switch to normal (non-capacitive) sensing mode
 #endif

--- a/k3ng_keyer/keyer_pin_settings_open_interface.h
+++ b/k3ng_keyer/keyer_pin_settings_open_interface.h
@@ -82,6 +82,10 @@
   #define keyer_awake 13       // Goes active when keyer is awake, inactive when in sleep mode; change active and inactive states in keyer_settings file
 #endif
 
+#if defined(FEATURE_LCD_BACKLIGHT_AUTO_DIM)
+  #define keyer_power_led 0   // must be a PWM-capable pin
+#endif
+
 #if defined(FEATURE_CAPACITIVE_PADDLE_PINS)
   #define capactive_paddle_pin_inhibit_pin 0     // if this pin is defined and is set high, the capacitive paddle pins will switch to normal (non-capacitive) sensing mode
 #endif

--- a/k3ng_keyer/keyer_pin_settings_opencwkeyer_mk2.h
+++ b/k3ng_keyer/keyer_pin_settings_opencwkeyer_mk2.h
@@ -113,6 +113,10 @@ FEATURE_SIDETONE_SWITCH
   #define keyer_awake 0
 #endif
 
+#if defined(FEATURE_LCD_BACKLIGHT_AUTO_DIM)
+  #define keyer_power_led 0   // must be a PWM-capable pin
+#endif
+
 #if defined(FEATURE_CAPACITIVE_PADDLE_PINS)
   #define capactive_paddle_pin_inhibit_pin 0     // if this pin is defined and is set high, the capacitive paddle pins will switch to normal (non-capacitive) sensing mode
 #endif

--- a/k3ng_keyer/keyer_pin_settings_test.h
+++ b/k3ng_keyer/keyer_pin_settings_test.h
@@ -114,6 +114,10 @@
   #define keyer_awake 13       // Goes active when keyer is awake, inactive when in sleep mode; change active and inactive states in keyer_settings file
 #endif
 
+#if defined(FEATURE_LCD_BACKLIGHT_AUTO_DIM)
+  #define keyer_power_led 0   // must be a PWM-capable pin
+#endif
+
 #if defined(FEATURE_CAPACITIVE_PADDLE_PINS)
   #define capactive_paddle_pin_inhibit_pin 0     // if this pin is defined and is set high, the capacitive paddle pins will switch to normal (non-capacitive) sensing mode
 #endif

--- a/k3ng_keyer/keyer_pin_settings_test_everything.h
+++ b/k3ng_keyer/keyer_pin_settings_test_everything.h
@@ -128,6 +128,10 @@
   #define keyer_awake 13       // Goes active when keyer is awake, inactive when in sleep mode; change active and inactive states in keyer_settings file
 #endif
 
+#if defined(FEATURE_LCD_BACKLIGHT_AUTO_DIM)
+  #define keyer_power_led 0   // must be a PWM-capable pin
+#endif
+
 #if defined(FEATURE_CAPACITIVE_PADDLE_PINS)
   #define capactive_paddle_pin_inhibit_pin 0     // if this pin is defined and is set high, the capacitive paddle pins will switch to normal (non-capacitive) sensing mode
 #endif

--- a/k3ng_keyer/keyer_pin_settings_tinykeyer.h
+++ b/k3ng_keyer/keyer_pin_settings_tinykeyer.h
@@ -37,6 +37,10 @@
   #define keyer_awake 8       // Goes active when keyer is awake, inactive when in sleep mode; change active and inactive states in keyer_settings file
 #endif
 
+#if defined(FEATURE_LCD_BACKLIGHT_AUTO_DIM)
+  #define keyer_power_led 0   // must be a PWM-capable pin
+#endif
+
 /*
 FEATURE_SIDETONE_SWITCH
   Enabling this feature and an external toggle switch  adds switch control for playing cw sidetone.

--- a/k3ng_keyer/keyer_pin_settings_yaacwk.h
+++ b/k3ng_keyer/keyer_pin_settings_yaacwk.h
@@ -94,6 +94,10 @@ FEATURE_SIDETONE_SWITCH
   #define keyer_awake 0       // Goes active when keyer is awake, inactive when in sleep mode; change active and inactive states in keyer_settings file
 #endif
 
+#if defined(FEATURE_LCD_BACKLIGHT_AUTO_DIM)
+  #define keyer_power_led 0   // must be a PWM-capable pin
+#endif
+
 #if defined(FEATURE_CAPACITIVE_PADDLE_PINS)
   #define capactive_paddle_pin_inhibit_pin 0     // if this pin is defined and is set high, the capacitive paddle pins will switch to normal (non-capacitive) sensing mode
 #endif

--- a/k3ng_keyer/keyer_pin_settings_yccc_so2r_mini.h
+++ b/k3ng_keyer/keyer_pin_settings_yccc_so2r_mini.h
@@ -127,6 +127,10 @@ FEATURE_SIDETONE_SWITCH
   #define keyer_awake 0
 #endif
 
+#if defined(FEATURE_LCD_BACKLIGHT_AUTO_DIM)
+  #define keyer_power_led 0   // must be a PWM-capable pin
+#endif
+
 #if defined(FEATURE_CAPACITIVE_PADDLE_PINS)
   #define capactive_paddle_pin_inhibit_pin 0     // if this pin is defined and is set high, the capacitive paddle pins will switch to normal (non-capacitive) sensing mode
 #endif

--- a/k3ng_keyer/keyer_settings.h
+++ b/k3ng_keyer/keyer_settings.h
@@ -51,6 +51,7 @@
 #define serial_leading_zeros 1            // set to 1 to activate leading zeros in serial numbers (i.e. #1 = 001)
 #define serial_cut_numbers 0              // set to 1 to activate cut numbers in serial numbers (i.e. #10 = 1T, #19 = 1N)
 #define go_to_sleep_inactivity_time 10    // minutes - FEATURE_SLEEP
+#define dim_backlight_inactive_time 5     // minutes - FEATURE_LCD_BACKLIGHT_AUTO_DIM
 #define default_cmos_super_keyer_iambic_b_timing_percent 33 // use with FEATURE_CMOS_SUPER_KEYER_IAMBIC_B_TIMING; should be between 0 to 99 % (0% = true iambic b;100% = iambic a behavior)
 #define default_cw_echo_timing_factor 1.75 // "factory default" setting
 #define default_autospace_timing_factor 2.0 // "factory default" setting
@@ -181,7 +182,12 @@
 #if defined(FEATURE_SLEEP)
   #define KEYER_AWAKE_PIN_AWAKE_STATE HIGH
   #define KEYER_AWAKE_PIN_ASLEEP_STATE LOW
-#endif 
+#endif
+
+#if defined(FEATURE_LCD_BACKLIGHT_AUTO_DIM)
+  #define keyer_power_led_awake_duty 255   // PWM duty cycle. 0 is 0%, 255 is 100%
+  #define keyer_power_led_asleep_duty 25   // 25 is quite dim. Use 0 for off
+#endif
 
 #if defined(FEATURE_ETHERNET)
   // #define FEATURE_ETHERNET_IP {192,168,1,178}                      // default IP address ("192.168.1.178")

--- a/k3ng_keyer/keyer_settings_fk_10.h
+++ b/k3ng_keyer/keyer_settings_fk_10.h
@@ -72,6 +72,7 @@
 #define serial_leading_zeros 1            // set to 1 to activate leading zeros in serial numbers (i.e. #1 = 001)
 #define serial_cut_numbers 0              // set to 1 to activate cut numbers in serial numbers (i.e. #10 = 1T, #19 = 1N)
 #define go_to_sleep_inactivity_time 10    // minutes - FEATURE_SLEEP
+#define dim_backlight_inactive_time 5     // minutes - FEATURE_LCD_BACKLIGHT_AUTO_DIM
 #define default_cmos_super_keyer_iambic_b_timing_percent 33 // use with FEATURE_CMOS_SUPER_KEYER_IAMBIC_B_TIMING; should be between 0 to 99 % (0% = true iambic b;100% = iambic a behavior)
 #define default_cw_echo_timing_factor 1.75 // "factory default" setting
 #define default_autospace_timing_factor 2.0 // "factory default" setting
@@ -205,6 +206,11 @@
   #define KEYER_AWAKE_PIN_AWAKE_STATE HIGH
   #define KEYER_AWAKE_PIN_ASLEEP_STATE LOW
 #endif 
+
+#if defined(FEATURE_LCD_BACKLIGHT_AUTO_DIM)
+  #define keyer_power_led_awake_duty 255   // PWM duty cycle. 0 is 0%, 255 is 100%
+  #define keyer_power_led_asleep_duty 25   // 25 is quite dim. Use 0 for off
+#endif
 
 #if defined(FEATURE_ETHERNET)
   // #define FEATURE_ETHERNET_IP {192,168,1,178}                      // default IP address ("192.168.1.178")

--- a/k3ng_keyer/keyer_settings_fk_11.h
+++ b/k3ng_keyer/keyer_settings_fk_11.h
@@ -53,6 +53,7 @@
 #define serial_leading_zeros 1            // set to 1 to activate leading zeros in serial numbers (i.e. #1 = 001)
 #define serial_cut_numbers 0              // set to 1 to activate cut numbers in serial numbers (i.e. #10 = 1T, #19 = 1N)
 #define go_to_sleep_inactivity_time 10    // minutes - FEATURE_SLEEP
+#define dim_backlight_inactive_time 5     // minutes - FEATURE_LCD_BACKLIGHT_AUTO_DIM
 #define default_cmos_super_keyer_iambic_b_timing_percent 33 // use with FEATURE_CMOS_SUPER_KEYER_IAMBIC_B_TIMING; should be between 0 to 99 % (0% = true iambic b;100% = iambic a behavior)
 #define default_cw_echo_timing_factor 1.75 // "factory default" setting
 #define default_autospace_timing_factor 2.0 // "factory default" setting
@@ -186,6 +187,11 @@
   #define KEYER_AWAKE_PIN_AWAKE_STATE HIGH
   #define KEYER_AWAKE_PIN_ASLEEP_STATE LOW
 #endif 
+
+#if defined(FEATURE_LCD_BACKLIGHT_AUTO_DIM)
+  #define keyer_power_led_awake_duty 255   // PWM duty cycle. 0 is 0%, 255 is 100%
+  #define keyer_power_led_asleep_duty 25   // 25 is quite dim. Use 0 for off
+#endif
 
 #if defined(FEATURE_ETHERNET)
   // #define FEATURE_ETHERNET_IP {192,168,1,178}                      // default IP address ("192.168.1.178")

--- a/k3ng_keyer/keyer_settings_generic_STM32F103C.h
+++ b/k3ng_keyer/keyer_settings_generic_STM32F103C.h
@@ -58,6 +58,7 @@ GENERIC STM32F103C
 #define serial_leading_zeros 1            // set to 1 to activate leading zeros in serial numbers (i.e. #1 = 001)
 #define serial_cut_numbers 0              // set to 1 to activate cut numbers in serial numbers (i.e. #10 = 1T, #19 = 1N)
 #define go_to_sleep_inactivity_time 10    // minutes - FEATURE_SLEEP
+#define dim_backlight_inactive_time 5     // minutes - FEATURE_LCD_BACKLIGHT_AUTO_DIM
 #define default_cmos_super_keyer_iambic_b_timing_percent 33 // use with FEATURE_CMOS_SUPER_KEYER_IAMBIC_B_TIMING; should be between 0 to 99 % (0% = true iambic b;100% = iambic a behavior)
 #define default_cw_echo_timing_factor 1.75 // "factory default" setting
 #define default_autospace_timing_factor 2.0 // "factory default" setting
@@ -192,6 +193,11 @@ GENERIC STM32F103C
   #define KEYER_AWAKE_PIN_AWAKE_STATE HIGH
   #define KEYER_AWAKE_PIN_ASLEEP_STATE LOW
 #endif 
+
+#if defined(FEATURE_LCD_BACKLIGHT_AUTO_DIM)
+  #define keyer_power_led_awake_duty 255   // PWM duty cycle. 0 is 0%, 255 is 100%
+  #define keyer_power_led_asleep_duty 25   // 25 is quite dim. Use 0 for off
+#endif
 
 #if defined(FEATURE_ETHERNET)
   // #define FEATURE_ETHERNET_IP {192,168,1,178}                      // default IP address ("192.168.1.178")

--- a/k3ng_keyer/keyer_settings_iz3gme.h
+++ b/k3ng_keyer/keyer_settings_iz3gme.h
@@ -51,6 +51,7 @@
 #define serial_leading_zeros 1            // set to 1 to activate leading zeros in serial numbers (i.e. #1 = 001)
 #define serial_cut_numbers 0              // set to 1 to activate cut numbers in serial numbers (i.e. #10 = 1T, #19 = 1N)
 #define go_to_sleep_inactivity_time 10    // minutes - FEATURE_SLEEP
+#define dim_backlight_inactive_time 5     // minutes - FEATURE_LCD_BACKLIGHT_AUTO_DIM
 #define default_cmos_super_keyer_iambic_b_timing_percent 33 // use with FEATURE_CMOS_SUPER_KEYER_IAMBIC_B_TIMING; should be between 0 to 99 % (0% = true iambic b;100% = iambic a behavior)
 #define default_cw_echo_timing_factor 1.75 // "factory default" setting
 #define default_autospace_timing_factor 2.0 // "factory default" setting
@@ -184,6 +185,11 @@
   #define KEYER_AWAKE_PIN_AWAKE_STATE HIGH
   #define KEYER_AWAKE_PIN_ASLEEP_STATE LOW
 #endif 
+
+#if defined(FEATURE_LCD_BACKLIGHT_AUTO_DIM)
+  #define keyer_power_led_awake_duty 255   // PWM duty cycle. 0 is 0%, 255 is 100%
+  #define keyer_power_led_asleep_duty 25   // 25 is quite dim. Use 0 for off
+#endif
 
 #if defined(FEATURE_ETHERNET)
   // #define FEATURE_ETHERNET_IP {192,168,1,178}                      // default IP address ("192.168.1.178")

--- a/k3ng_keyer/keyer_settings_k5bcq.h
+++ b/k3ng_keyer/keyer_settings_k5bcq.h
@@ -51,6 +51,7 @@
 #define serial_leading_zeros 1            // set to 1 to activate leading zeros in serial numbers (i.e. #1 = 001)
 #define serial_cut_numbers 0              // set to 1 to activate cut numbers in serial numbers (i.e. #10 = 1T, #19 = 1N)
 #define go_to_sleep_inactivity_time 10    // minutes - FEATURE_SLEEP
+#define dim_backlight_inactive_time 5     // minutes - FEATURE_LCD_BACKLIGHT_AUTO_DIM
 #define default_cmos_super_keyer_iambic_b_timing_percent 33 // use with FEATURE_CMOS_SUPER_KEYER_IAMBIC_B_TIMING; should be between 0 to 99 % (0% = true iambic b;100% = iambic a behavior)
 #define default_cw_echo_timing_factor 1.75 // "factory default" setting
 #define default_autospace_timing_factor 2.0 // "factory default" setting
@@ -184,6 +185,11 @@
   #define KEYER_AWAKE_PIN_AWAKE_STATE HIGH
   #define KEYER_AWAKE_PIN_ASLEEP_STATE LOW
 #endif 
+
+#if defined(FEATURE_LCD_BACKLIGHT_AUTO_DIM)
+  #define keyer_power_led_awake_duty 255   // PWM duty cycle. 0 is 0%, 255 is 100%
+  #define keyer_power_led_asleep_duty 25   // 25 is quite dim. Use 0 for off
+#endif
 
 #if defined(FEATURE_ETHERNET)
   // #define FEATURE_ETHERNET_IP {192,168,1,178}                      // default IP address ("192.168.1.178")

--- a/k3ng_keyer/keyer_settings_maple_mini.h
+++ b/k3ng_keyer/keyer_settings_maple_mini.h
@@ -64,6 +64,7 @@
 #define serial_leading_zeros 1            // set to 1 to activate leading zeros in serial numbers (i.e. #1 = 001)
 #define serial_cut_numbers 0              // set to 1 to activate cut numbers in serial numbers (i.e. #10 = 1T, #19 = 1N)
 #define go_to_sleep_inactivity_time 10    // minutes - FEATURE_SLEEP
+#define dim_backlight_inactive_time 5     // minutes - FEATURE_LCD_BACKLIGHT_AUTO_DIM
 #define default_cmos_super_keyer_iambic_b_timing_percent 33 // use with FEATURE_CMOS_SUPER_KEYER_IAMBIC_B_TIMING; should be between 0 to 99 % (0% = true iambic b;100% = iambic a behavior)
 #define default_cw_echo_timing_factor 1.75 // "factory default" setting
 #define default_autospace_timing_factor 2.0 // "factory default" setting
@@ -197,6 +198,11 @@
   #define KEYER_AWAKE_PIN_AWAKE_STATE HIGH
   #define KEYER_AWAKE_PIN_ASLEEP_STATE LOW
 #endif 
+
+#if defined(FEATURE_LCD_BACKLIGHT_AUTO_DIM)
+  #define keyer_power_led_awake_duty 255   // PWM duty cycle. 0 is 0%, 255 is 100%
+  #define keyer_power_led_asleep_duty 25   // 25 is quite dim. Use 0 for off
+#endif
 
 #if defined(FEATURE_ETHERNET)
   // #define FEATURE_ETHERNET_IP {192,168,1,178}                      // default IP address ("192.168.1.178")

--- a/k3ng_keyer/keyer_settings_megakeyer.h
+++ b/k3ng_keyer/keyer_settings_megakeyer.h
@@ -56,6 +56,7 @@
 #define serial_leading_zeros 1            // set to 1 to activate leading zeros in serial numbers (i.e. #1 = 001)
 #define serial_cut_numbers 0              // set to 1 to activate cut numbers in serial numbers (i.e. #10 = 1T, #19 = 1N)
 #define go_to_sleep_inactivity_time 10    // minutes - FEATURE_SLEEP
+#define dim_backlight_inactive_time 5     // minutes - FEATURE_LCD_BACKLIGHT_AUTO_DIM
 #define default_cmos_super_keyer_iambic_b_timing_percent 33 // use with FEATURE_CMOS_SUPER_KEYER_IAMBIC_B_TIMING; should be between 0 to 99 % (0% = true iambic b;100% = iambic a behavior)
 #define default_cw_echo_timing_factor 1.75 // "factory default" setting
 #define default_autospace_timing_factor 2.0 // "factory default" setting
@@ -189,6 +190,11 @@
   #define KEYER_AWAKE_PIN_AWAKE_STATE HIGH
   #define KEYER_AWAKE_PIN_ASLEEP_STATE LOW
 #endif 
+
+#if defined(FEATURE_LCD_BACKLIGHT_AUTO_DIM)
+  #define keyer_power_led_awake_duty 255   // PWM duty cycle. 0 is 0%, 255 is 100%
+  #define keyer_power_led_asleep_duty 25   // 25 is quite dim. Use 0 for off
+#endif
 
 #if defined(FEATURE_ETHERNET)
   // #define FEATURE_ETHERNET_IP {192,168,1,178}                      // default IP address ("192.168.1.178")

--- a/k3ng_keyer/keyer_settings_mortty.h
+++ b/k3ng_keyer/keyer_settings_mortty.h
@@ -51,6 +51,7 @@
 #define serial_leading_zeros 1            // set to 1 to activate leading zeros in serial numbers (i.e. #1 = 001)
 #define serial_cut_numbers 0              // set to 1 to activate cut numbers in serial numbers (i.e. #10 = 1T, #19 = 1N)
 #define go_to_sleep_inactivity_time 10    // minutes - FEATURE_SLEEP
+#define dim_backlight_inactive_time 5     // minutes - FEATURE_LCD_BACKLIGHT_AUTO_DIM
 #define default_cmos_super_keyer_iambic_b_timing_percent 33 // use with FEATURE_CMOS_SUPER_KEYER_IAMBIC_B_TIMING; should be between 0 to 99 % (0% = true iambic b;100% = iambic a behavior)
 #define default_cw_echo_timing_factor 1.75 // "factory default" setting
 #define default_autospace_timing_factor 2.0 // "factory default" setting
@@ -184,6 +185,11 @@
   #define KEYER_AWAKE_PIN_AWAKE_STATE HIGH
   #define KEYER_AWAKE_PIN_ASLEEP_STATE LOW
 #endif 
+
+#if defined(FEATURE_LCD_BACKLIGHT_AUTO_DIM)
+  #define keyer_power_led_awake_duty 255   // PWM duty cycle. 0 is 0%, 255 is 100%
+  #define keyer_power_led_asleep_duty 25   // 25 is quite dim. Use 0 for off
+#endif
 
 #if defined(FEATURE_ETHERNET)
   // #define FEATURE_ETHERNET_IP {192,168,1,178}                      // default IP address ("192.168.1.178")

--- a/k3ng_keyer/keyer_settings_mortty_regular.h
+++ b/k3ng_keyer/keyer_settings_mortty_regular.h
@@ -51,6 +51,7 @@
 #define serial_leading_zeros 1            // set to 1 to activate leading zeros in serial numbers (i.e. #1 = 001)
 #define serial_cut_numbers 0              // set to 1 to activate cut numbers in serial numbers (i.e. #10 = 1T, #19 = 1N)
 #define go_to_sleep_inactivity_time 10    // minutes - FEATURE_SLEEP
+#define dim_backlight_inactive_time 5     // minutes - FEATURE_LCD_BACKLIGHT_AUTO_DIM
 #define default_cmos_super_keyer_iambic_b_timing_percent 33 // use with FEATURE_CMOS_SUPER_KEYER_IAMBIC_B_TIMING; should be between 0 to 99 % (0% = true iambic b;100% = iambic a behavior)
 #define default_cw_echo_timing_factor 1.75 // "factory default" setting
 #define default_autospace_timing_factor 2.0 // "factory default" setting
@@ -184,6 +185,11 @@
   #define KEYER_AWAKE_PIN_AWAKE_STATE HIGH
   #define KEYER_AWAKE_PIN_ASLEEP_STATE LOW
 #endif 
+
+#if defined(FEATURE_LCD_BACKLIGHT_AUTO_DIM)
+  #define keyer_power_led_awake_duty 255   // PWM duty cycle. 0 is 0%, 255 is 100%
+  #define keyer_power_led_asleep_duty 25   // 25 is quite dim. Use 0 for off
+#endif
 
 #if defined(FEATURE_ETHERNET)
   // #define FEATURE_ETHERNET_IP {192,168,1,178}                      // default IP address ("192.168.1.178")

--- a/k3ng_keyer/keyer_settings_mortty_regular_with_potentiometer.h
+++ b/k3ng_keyer/keyer_settings_mortty_regular_with_potentiometer.h
@@ -51,6 +51,7 @@
 #define serial_leading_zeros 1            // set to 1 to activate leading zeros in serial numbers (i.e. #1 = 001)
 #define serial_cut_numbers 0              // set to 1 to activate cut numbers in serial numbers (i.e. #10 = 1T, #19 = 1N)
 #define go_to_sleep_inactivity_time 10    // minutes - FEATURE_SLEEP
+#define dim_backlight_inactive_time 5     // minutes - FEATURE_LCD_BACKLIGHT_AUTO_DIM
 #define default_cmos_super_keyer_iambic_b_timing_percent 33 // use with FEATURE_CMOS_SUPER_KEYER_IAMBIC_B_TIMING; should be between 0 to 99 % (0% = true iambic b;100% = iambic a behavior)
 #define default_cw_echo_timing_factor 1.75 // "factory default" setting
 #define default_autospace_timing_factor 2.0 // "factory default" setting
@@ -184,6 +185,11 @@
   #define KEYER_AWAKE_PIN_AWAKE_STATE HIGH
   #define KEYER_AWAKE_PIN_ASLEEP_STATE LOW
 #endif 
+
+#if defined(FEATURE_LCD_BACKLIGHT_AUTO_DIM)
+  #define keyer_power_led_awake_duty 255   // PWM duty cycle. 0 is 0%, 255 is 100%
+  #define keyer_power_led_asleep_duty 25   // 25 is quite dim. Use 0 for off
+#endif
 
 #if defined(FEATURE_ETHERNET)
   // #define FEATURE_ETHERNET_IP {192,168,1,178}                      // default IP address ("192.168.1.178")

--- a/k3ng_keyer/keyer_settings_mortty_so2r.h
+++ b/k3ng_keyer/keyer_settings_mortty_so2r.h
@@ -51,6 +51,7 @@
 #define serial_leading_zeros 1            // set to 1 to activate leading zeros in serial numbers (i.e. #1 = 001)
 #define serial_cut_numbers 0              // set to 1 to activate cut numbers in serial numbers (i.e. #10 = 1T, #19 = 1N)
 #define go_to_sleep_inactivity_time 10    // minutes - FEATURE_SLEEP
+#define dim_backlight_inactive_time 5     // minutes - FEATURE_LCD_BACKLIGHT_AUTO_DIM
 #define default_cmos_super_keyer_iambic_b_timing_percent 33 // use with FEATURE_CMOS_SUPER_KEYER_IAMBIC_B_TIMING; should be between 0 to 99 % (0% = true iambic b;100% = iambic a behavior)
 #define default_cw_echo_timing_factor 1.75 // "factory default" setting
 #define default_autospace_timing_factor 2.0 // "factory default" setting
@@ -184,6 +185,11 @@
   #define KEYER_AWAKE_PIN_AWAKE_STATE HIGH
   #define KEYER_AWAKE_PIN_ASLEEP_STATE LOW
 #endif 
+
+#if defined(FEATURE_LCD_BACKLIGHT_AUTO_DIM)
+  #define keyer_power_led_awake_duty 255   // PWM duty cycle. 0 is 0%, 255 is 100%
+  #define keyer_power_led_asleep_duty 25   // 25 is quite dim. Use 0 for off
+#endif
 
 #if defined(FEATURE_ETHERNET)
   // #define FEATURE_ETHERNET_IP {192,168,1,178}                      // default IP address ("192.168.1.178")

--- a/k3ng_keyer/keyer_settings_mortty_so2r_with_potentiometer.h
+++ b/k3ng_keyer/keyer_settings_mortty_so2r_with_potentiometer.h
@@ -51,6 +51,7 @@
 #define serial_leading_zeros 1            // set to 1 to activate leading zeros in serial numbers (i.e. #1 = 001)
 #define serial_cut_numbers 0              // set to 1 to activate cut numbers in serial numbers (i.e. #10 = 1T, #19 = 1N)
 #define go_to_sleep_inactivity_time 10    // minutes - FEATURE_SLEEP
+#define dim_backlight_inactive_time 5     // minutes - FEATURE_LCD_BACKLIGHT_AUTO_DIM
 #define default_cmos_super_keyer_iambic_b_timing_percent 33 // use with FEATURE_CMOS_SUPER_KEYER_IAMBIC_B_TIMING; should be between 0 to 99 % (0% = true iambic b;100% = iambic a behavior)
 #define default_cw_echo_timing_factor 1.75 // "factory default" setting
 #define default_autospace_timing_factor 2.0 // "factory default" setting
@@ -184,6 +185,11 @@
   #define KEYER_AWAKE_PIN_AWAKE_STATE HIGH
   #define KEYER_AWAKE_PIN_ASLEEP_STATE LOW
 #endif 
+
+#if defined(FEATURE_LCD_BACKLIGHT_AUTO_DIM)
+  #define keyer_power_led_awake_duty 255   // PWM duty cycle. 0 is 0%, 255 is 100%
+  #define keyer_power_led_asleep_duty 25   // 25 is quite dim. Use 0 for off
+#endif
 
 #if defined(FEATURE_ETHERNET)
   // #define FEATURE_ETHERNET_IP {192,168,1,178}                      // default IP address ("192.168.1.178")

--- a/k3ng_keyer/keyer_settings_nanokeyer_rev_b.h
+++ b/k3ng_keyer/keyer_settings_nanokeyer_rev_b.h
@@ -51,6 +51,7 @@
 #define serial_leading_zeros 1            // set to 1 to activate leading zeros in serial numbers (i.e. #1 = 001)
 #define serial_cut_numbers 0              // set to 1 to activate cut numbers in serial numbers (i.e. #10 = 1T, #19 = 1N)
 #define go_to_sleep_inactivity_time 10    // minutes - FEATURE_SLEEP
+#define dim_backlight_inactive_time 5     // minutes - FEATURE_LCD_BACKLIGHT_AUTO_DIM
 #define default_cmos_super_keyer_iambic_b_timing_percent 33 // use with FEATURE_CMOS_SUPER_KEYER_IAMBIC_B_TIMING; should be between 0 to 99 % (0% = true iambic b;100% = iambic a behavior)
 #define default_cw_echo_timing_factor 1.75 // "factory default" setting
 #define default_autospace_timing_factor 2.0 // "factory default" setting
@@ -173,6 +174,11 @@
 #if defined(FEATURE_SLEEP)
   #define KEYER_AWAKE_PIN_AWAKE_STATE HIGH
   #define KEYER_AWAKE_PIN_ASLEEP_STATE LOW
+#endif
+
+#if defined(FEATURE_LCD_BACKLIGHT_AUTO_DIM)
+  #define keyer_power_led_awake_duty 255   // PWM duty cycle. 0 is 0%, 255 is 100%
+  #define keyer_power_led_asleep_duty 25   // 25 is quite dim. Use 0 for off
 #endif
 
 #if defined(FEATURE_ETHERNET)

--- a/k3ng_keyer/keyer_settings_nanokeyer_rev_d.h
+++ b/k3ng_keyer/keyer_settings_nanokeyer_rev_d.h
@@ -51,6 +51,7 @@
 #define serial_leading_zeros 1            // set to 1 to activate leading zeros in serial numbers (i.e. #1 = 001)
 #define serial_cut_numbers 0              // set to 1 to activate cut numbers in serial numbers (i.e. #10 = 1T, #19 = 1N)
 #define go_to_sleep_inactivity_time 10    // minutes - FEATURE_SLEEP
+#define dim_backlight_inactive_time 5     // minutes - FEATURE_LCD_BACKLIGHT_AUTO_DIM
 #define default_cmos_super_keyer_iambic_b_timing_percent 33 // use with FEATURE_CMOS_SUPER_KEYER_IAMBIC_B_TIMING; should be between 0 to 99 % (0% = true iambic b;100% = iambic a behavior)
 #define default_cw_echo_timing_factor 1.75 // "factory default" setting
 #define default_autospace_timing_factor 2.0 // "factory default" setting
@@ -174,6 +175,11 @@
 #if defined(FEATURE_SLEEP)
   #define KEYER_AWAKE_PIN_AWAKE_STATE HIGH
   #define KEYER_AWAKE_PIN_ASLEEP_STATE LOW
+#endif
+
+#if defined(FEATURE_LCD_BACKLIGHT_AUTO_DIM)
+  #define keyer_power_led_awake_duty 255   // PWM duty cycle. 0 is 0%, 255 is 100%
+  #define keyer_power_led_asleep_duty 25   // 25 is quite dim. Use 0 for off
 #endif
 
 #if defined(FEATURE_ETHERNET)

--- a/k3ng_keyer/keyer_settings_open_interface.h
+++ b/k3ng_keyer/keyer_settings_open_interface.h
@@ -53,6 +53,7 @@
 #define serial_leading_zeros 1            // set to 1 to activate leading zeros in serial numbers (i.e. #1 = 001)
 #define serial_cut_numbers 0              // set to 1 to activate cut numbers in serial numbers (i.e. #10 = 1T, #19 = 1N)
 #define go_to_sleep_inactivity_time 10    // minutes - FEATURE_SLEEP
+#define dim_backlight_inactive_time 5     // minutes - FEATURE_LCD_BACKLIGHT_AUTO_DIM
 #define default_cmos_super_keyer_iambic_b_timing_percent 33 // use with FEATURE_CMOS_SUPER_KEYER_IAMBIC_B_TIMING; should be between 0 to 99 % (0% = true iambic b;100% = iambic a behavior)
 #define default_cw_echo_timing_factor 1.75 // "factory default" setting
 #define default_autospace_timing_factor 2.0 // "factory default" setting
@@ -176,6 +177,11 @@
 #if defined(FEATURE_SLEEP)
   #define KEYER_AWAKE_PIN_AWAKE_STATE HIGH
   #define KEYER_AWAKE_PIN_ASLEEP_STATE LOW
+#endif
+
+#if defined(FEATURE_LCD_BACKLIGHT_AUTO_DIM)
+  #define keyer_power_led_awake_duty 255   // PWM duty cycle. 0 is 0%, 255 is 100%
+  #define keyer_power_led_asleep_duty 25   // 25 is quite dim. Use 0 for off
 #endif
 
 #if defined(FEATURE_ETHERNET)

--- a/k3ng_keyer/keyer_settings_opencwkeyer_mk2.h
+++ b/k3ng_keyer/keyer_settings_opencwkeyer_mk2.h
@@ -51,6 +51,7 @@
 #define serial_leading_zeros 1            // set to 1 to activate leading zeros in serial numbers (i.e. #1 = 001)
 #define serial_cut_numbers 0              // set to 1 to activate cut numbers in serial numbers (i.e. #10 = 1T, #19 = 1N)
 #define go_to_sleep_inactivity_time 10    // minutes - FEATURE_SLEEP
+#define dim_backlight_inactive_time 5     // minutes - FEATURE_LCD_BACKLIGHT_AUTO_DIM
 #define default_cmos_super_keyer_iambic_b_timing_percent 33 // use with FEATURE_CMOS_SUPER_KEYER_IAMBIC_B_TIMING; should be between 0 to 99 % (0% = true iambic b;100% = iambic a behavior)
 #define default_cw_echo_timing_factor 1.75 // "factory default" setting
 #define default_autospace_timing_factor 2.0 // "factory default" setting
@@ -184,6 +185,11 @@
   #define KEYER_AWAKE_PIN_AWAKE_STATE HIGH
   #define KEYER_AWAKE_PIN_ASLEEP_STATE LOW
 #endif 
+
+#if defined(FEATURE_LCD_BACKLIGHT_AUTO_DIM)
+  #define keyer_power_led_awake_duty 255   // PWM duty cycle. 0 is 0%, 255 is 100%
+  #define keyer_power_led_asleep_duty 25   // 25 is quite dim. Use 0 for off
+#endif
 
 #if defined(FEATURE_ETHERNET)
   // #define FEATURE_ETHERNET_IP {192,168,1,178}                      // default IP address ("192.168.1.178")

--- a/k3ng_keyer/keyer_settings_test.h
+++ b/k3ng_keyer/keyer_settings_test.h
@@ -64,6 +64,7 @@
 #define serial_leading_zeros 1            // set to 1 to activate leading zeros in serial numbers (i.e. #1 = 001)
 #define serial_cut_numbers 0              // set to 1 to activate cut numbers in serial numbers (i.e. #10 = 1T, #19 = 1N)
 #define go_to_sleep_inactivity_time 10    // minutes - FEATURE_SLEEP
+#define dim_backlight_inactive_time 5     // minutes - FEATURE_LCD_BACKLIGHT_AUTO_DIM
 #define default_cmos_super_keyer_iambic_b_timing_percent 33 // use with FEATURE_CMOS_SUPER_KEYER_IAMBIC_B_TIMING; should be between 0 to 99 % (0% = true iambic b;100% = iambic a behavior)
 #define default_cw_echo_timing_factor 1.75 // "factory default" setting
 #define default_autospace_timing_factor 2.0 // "factory default" setting
@@ -195,6 +196,11 @@
 #if defined(FEATURE_SLEEP)
   #define KEYER_AWAKE_PIN_AWAKE_STATE HIGH
   #define KEYER_AWAKE_PIN_ASLEEP_STATE LOW
+#endif
+
+#if defined(FEATURE_LCD_BACKLIGHT_AUTO_DIM)
+  #define keyer_power_led_awake_duty 255   // PWM duty cycle. 0 is 0%, 255 is 100%
+  #define keyer_power_led_asleep_duty 25   // 25 is quite dim. Use 0 for off
 #endif
 
 #if defined(FEATURE_ETHERNET)

--- a/k3ng_keyer/keyer_settings_test_everything.h
+++ b/k3ng_keyer/keyer_settings_test_everything.h
@@ -61,6 +61,7 @@
 #define serial_leading_zeros 1            // set to 1 to activate leading zeros in serial numbers (i.e. #1 = 001)
 #define serial_cut_numbers 0              // set to 1 to activate cut numbers in serial numbers (i.e. #10 = 1T, #19 = 1N)
 #define go_to_sleep_inactivity_time 10    // minutes - FEATURE_SLEEP
+#define dim_backlight_inactive_time 5     // minutes - FEATURE_LCD_BACKLIGHT_AUTO_DIM
 #define default_cmos_super_keyer_iambic_b_timing_percent 33 // use with FEATURE_CMOS_SUPER_KEYER_IAMBIC_B_TIMING; should be between 0 to 99 % (0% = true iambic b;100% = iambic a behavior)
 #define default_cw_echo_timing_factor 1.75 // "factory default" setting
 #define default_autospace_timing_factor 2.0 // "factory default" setting
@@ -192,6 +193,11 @@
 #if defined(FEATURE_SLEEP)
   #define KEYER_AWAKE_PIN_AWAKE_STATE HIGH
   #define KEYER_AWAKE_PIN_ASLEEP_STATE LOW
+#endif
+
+#if defined(FEATURE_LCD_BACKLIGHT_AUTO_DIM)
+  #define keyer_power_led_awake_duty 255   // PWM duty cycle. 0 is 0%, 255 is 100%
+  #define keyer_power_led_asleep_duty 25   // 25 is quite dim. Use 0 for off
 #endif
 
 #if defined(FEATURE_ETHERNET)

--- a/k3ng_keyer/keyer_settings_tinykeyer.h
+++ b/k3ng_keyer/keyer_settings_tinykeyer.h
@@ -52,6 +52,7 @@
 #define serial_leading_zeros 1            // set to 1 to activate leading zeros in serial numbers (i.e. #1 = 001)
 #define serial_cut_numbers 0              // set to 1 to activate cut numbers in serial numbers (i.e. #10 = 1T, #19 = 1N)
 #define go_to_sleep_inactivity_time 10    // minutes - FEATURE_SLEEP
+#define dim_backlight_inactive_time 5     // minutes - FEATURE_LCD_BACKLIGHT_AUTO_DIM
 #define default_cmos_super_keyer_iambic_b_timing_percent 33 // use with FEATURE_CMOS_SUPER_KEYER_IAMBIC_B_TIMING; should be between 0 to 99 % (0% = true iambic b;100% = iambic a behavior)
 #define default_cw_echo_timing_factor 1.75 // "factory default" setting
 #define default_autospace_timing_factor 2.0 // "factory default" setting
@@ -174,6 +175,11 @@
 #if defined(FEATURE_SLEEP)
   #define KEYER_AWAKE_PIN_AWAKE_STATE HIGH
   #define KEYER_AWAKE_PIN_ASLEEP_STATE LOW
+#endif
+
+#if defined(FEATURE_LCD_BACKLIGHT_AUTO_DIM)
+  #define keyer_power_led_awake_duty 255   // PWM duty cycle. 0 is 0%, 255 is 100%
+  #define keyer_power_led_asleep_duty 25   // 25 is quite dim. Use 0 for off
 #endif
 
 #if defined(FEATURE_ETHERNET)

--- a/k3ng_keyer/keyer_settings_yaacwk.h
+++ b/k3ng_keyer/keyer_settings_yaacwk.h
@@ -51,6 +51,7 @@
 #define serial_leading_zeros 1            // set to 1 to activate leading zeros in serial numbers (i.e. #1 = 001)
 #define serial_cut_numbers 0              // set to 1 to activate cut numbers in serial numbers (i.e. #10 = 1T, #19 = 1N)
 #define go_to_sleep_inactivity_time 10    // minutes - FEATURE_SLEEP
+#define dim_backlight_inactive_time 5     // minutes - FEATURE_LCD_BACKLIGHT_AUTO_DIM
 #define default_cmos_super_keyer_iambic_b_timing_percent 33 // use with FEATURE_CMOS_SUPER_KEYER_IAMBIC_B_TIMING; should be between 0 to 99 % (0% = true iambic b;100% = iambic a behavior)
 #define default_cw_echo_timing_factor 1.75 // "factory default" setting
 #define default_autospace_timing_factor 2.0 // "factory default" setting
@@ -182,6 +183,11 @@
 #if defined(FEATURE_SLEEP)
   #define KEYER_AWAKE_PIN_AWAKE_STATE HIGH
   #define KEYER_AWAKE_PIN_ASLEEP_STATE LOW
+#endif
+
+#if defined(FEATURE_LCD_BACKLIGHT_AUTO_DIM)
+  #define keyer_power_led_awake_duty 255   // PWM duty cycle. 0 is 0%, 255 is 100%
+  #define keyer_power_led_asleep_duty 25   // 25 is quite dim. Use 0 for off
 #endif
 
 #if defined(FEATURE_ETHERNET)

--- a/k3ng_keyer/keyer_settings_yccc_so2r_mini.h
+++ b/k3ng_keyer/keyer_settings_yccc_so2r_mini.h
@@ -51,6 +51,7 @@
 #define serial_leading_zeros 1            // set to 1 to activate leading zeros in serial numbers (i.e. #1 = 001)
 #define serial_cut_numbers 0              // set to 1 to activate cut numbers in serial numbers (i.e. #10 = 1T, #19 = 1N)
 #define go_to_sleep_inactivity_time 10    // minutes - FEATURE_SLEEP
+#define dim_backlight_inactive_time 5     // minutes - FEATURE_LCD_BACKLIGHT_AUTO_DIM
 #define default_cmos_super_keyer_iambic_b_timing_percent 33 // use with FEATURE_CMOS_SUPER_KEYER_IAMBIC_B_TIMING; should be between 0 to 99 % (0% = true iambic b;100% = iambic a behavior)
 #define default_cw_echo_timing_factor 1.75 // "factory default" setting
 #define default_autospace_timing_factor 2.0 // "factory default" setting
@@ -184,6 +185,11 @@
   #define KEYER_AWAKE_PIN_AWAKE_STATE HIGH
   #define KEYER_AWAKE_PIN_ASLEEP_STATE LOW
 #endif 
+
+#if defined(FEATURE_LCD_BACKLIGHT_AUTO_DIM)
+  #define keyer_power_led_awake_duty 255   // PWM duty cycle. 0 is 0%, 255 is 100%
+  #define keyer_power_led_asleep_duty 25   // 25 is quite dim. Use 0 for off
+#endif
 
 #if defined(FEATURE_ETHERNET)
   // #define FEATURE_ETHERNET_IP {192,168,1,178}                      // default IP address ("192.168.1.178")


### PR DESCRIPTION
…minutes

Feature simply tracks last active time. After x minutes of no activity, `lcd.noBacklight()` is called (assuming FEATURE_DISPLAY), which turns off the LCD's backlight. Additionally, `analogWrite(keyer_power_led,keyer_power_led_asleep_duty);` is called to dim the optional Power LED.  If anything is written to the LCD, or button is pressed, or encoder is turned, or keyboard key is pressed, then `lcd.backlight()` is called to switch on the backlight, and `keyer_power_led_awake_duty` is used for PWM to LED.  
To save cycles, `check_backlight()` usually returns immediately and will only dim/brighten once per second.

Defines are added to all of: keyer_debug.h, keyer_features_and_options*.h, keyer_pin_settings*.h, and keyer_settings*.h.

- Feature is commented out by default. 
- Default LED pin is zero (not used). 
- Default LED asleep duty cycle is 25/255 (pretty dim). 
- Default LED awake is 255/255 (full on).

- I added an last active time update at the end of check_sleep() after CPU awakens so backlight also comes on. 
- I added #ifdef'd calls to lcd.backlight() in service_display() to ensure that paths that were about to write characters did so to a lit LCD. I didn't add active time updates there, since it's taken care of elsewhere -- I just didn't want a second to go by with a dim LCD.
- I also added an active time update check in check_rotary_encoder(). I mention this because there was not a update for Sleep time, but maybe there should be? I think you can turn the encoder just seconds before it sleeps, and maybe the CPU would still Sleep rather than be put off another 10 minutes?  I needed it because otherwise you could touch the encoder and the lights stayed off.
- Otherwise, I just dropped in an #ifdef'd last active time update where there was one for Sleep.  I use a different variable so that you can use both features together (dim in 5 minutes, sleep in 10 minutes).
 
**Potential Issues**

1. I only tested with FEATURE_LDC_YDv1.  Specifically, I'm not certain the non-I2C boards use lcd.noBacklight() and lcd.backlight().
2. I see the Adafruit has a colored backlight. I didn't do anything about saving / restoring that color.
3. At first I thought about running the backlight off PWM as well (so you could control brightness when awake or asleep), but that seemed needlessly complex in circuitry (might need a transistor if board PWM pin can't supply enough current) for little value.
4. I don't see how to update documentation, or I'd happily add a sentence to the DISPLAY doc pages to mention this possibility.