### PR TITLE
Add support for STM32F1 boards.

### DIFF
--- a/libraries/K3NG_PS2Keyboard/K3NG_PS2Keyboard.h
+++ b/libraries/K3NG_PS2Keyboard/K3NG_PS2Keyboard.h
@@ -34,6 +34,9 @@ K3NG Updates
   2015101401
     Fixed issues with CTRL and ALT key combinations with German and French keyboards
 
+7M4MON Updates
+  20210215
+    Add support for STM32F1 boards. (Marged from "https://github.com/Tamakichi/Arduino_PS2Keyboard" by Tamakichi. Tested with STM32F103C Boads).
 
 */
 
@@ -50,10 +53,16 @@ K3NG Updates
 // #define OPTION_PS2_KEYBOARD_GERMAN
 // #define OPTION_PS2_KEYBOARD_FRENCH
 
-#if !defined(ARDUINO_SAM_DUE)
+#if !defined(ARDUINO_SAM_DUE) && !defined (__STM32F1__)
   #include <avr/io.h>
   #include <avr/interrupt.h>
   #include <avr/pgmspace.h>
+#endif
+
+#if defined(ARDUINO) && ARDUINO >= 100
+#include "Arduino.h" // for attachInterrupt, FALLING
+#else
+#include "WProgram.h"
 #endif
 
 // Every call to read() returns a single byte for each

--- a/libraries/K3NG_PS2Keyboard/library.properties
+++ b/libraries/K3NG_PS2Keyboard/library.properties
@@ -6,5 +6,5 @@ sentence=For use with the K3NG CW Keyer for PS2 keyboard support
 paragraph=For use with the K3NG CW Keyer for PS2 keyboard support
 category=Uncategorized
 url=https://github.com/k3ng/k3ng_cw_keyer
-architectures=avr
+architectures=avr,STM32F1
 includes=K3NG_PS2Keyboard.h


### PR DESCRIPTION
Add support for STM32F1 boards. (Marged from "https://github.com/Tamakichi/Arduino_PS2Keyboard" by Tamakichi. Tested with STM32F103C Boads).
