### PR TITLE
Update k3ng_keyer.ino

### DIFF
--- a/k3ng_keyer/k3ng_keyer.ino
+++ b/k3ng_keyer/k3ng_keyer.ino
@@ -8023,6 +8023,14 @@ void command_mode() {
   #ifdef OPTION_WATCHDOG_TIMER
     wdt_enable(WDTO_4S);
   #endif //OPTION_WATCHDOG_TIMER
+	
+  #ifdef FEATURE_DISPLAY
+    lcd.clear();
+    for (int x = 0; x < LCD_ROWS; x++) {        // as we exit, redraw the display that we had before we went into Command Mode
+      lcd.setCursor(0, x);
+      lcd.print(lcd_scroll_buffer[x]);
+    }
+  #endif                                        // FEATURE_DISPLAY
 
 }
 #endif //FEATURE_COMMAND_MODE


### PR DESCRIPTION
Previously, when exiting Command Mode the screen was cleared and left blank. The display would then only be restored if you entered a character from the paddles or pressed a memory button.
This code always restores the display as you exit Command Mode. It does this simply by rewriting the saved screen buffer arrays to the display.
Only relevant if FEATURE_DISPLAY is defined.
The code for the for loop was plagiarised from the service_display() function.