### PR TITLE
Support of RP2040 board and new hardware

### DIFF
--- a/k3ng_keyer/k3ng_keyer.ino
+++ b/k3ng_keyer/k3ng_keyer.ino
@@ -1404,11 +1404,15 @@ If you offer a hardware kit using this software, show your appreciation by sendi
   #include <FlashAsEEPROM.h>
 #else
   #include <avr/pgmspace.h>
-  #include <avr/wdt.h>
+//  #include <avr/wdt.h> zmena
   #include <EEPROM.h>
 #endif //ARDUINO_SAM_DUE
 
-#if defined(HARDWARE_OPENCWKEYER_MK2)
+
+
+#if defined(HARDWARE_OPENCWKEYER_MK3)
+  #include "keyer_features_and_options_opencwkeyer_mk3.h"
+#elif defined(HARDWARE_OPENCWKEYER_MK2)  
   #include "keyer_features_and_options_opencwkeyer_mk2.h"
 #elif defined(HARDWARE_NANOKEYER_REV_B)
   #include "keyer_features_and_options_nanokeyer_rev_b.h"
@@ -1464,7 +1468,11 @@ If you offer a hardware kit using this software, show your appreciation by sendi
 #include "keyer_dependencies.h"
 #include "keyer_debug.h"
 
-#if defined(HARDWARE_OPENCWKEYER_MK2)
+
+#if defined(HARDWARE_OPENCWKEYER_MK3)
+  #include "keyer_pin_settings_opencwkeyer_mk3.h"
+  #include "keyer_settings_opencwkeyer_mk3.h"
+#elif defined(HARDWARE_OPENCWKEYER_MK2)
   #include "keyer_pin_settings_opencwkeyer_mk2.h"
   #include "keyer_settings_opencwkeyer_mk2.h"
 #elif defined(HARDWARE_NANOKEYER_REV_B)
@@ -1532,10 +1540,11 @@ If you offer a hardware kit using this software, show your appreciation by sendi
   #include "keyer_settings.h"
 #endif
 
-#if (paddle_left == 0) || (paddle_right == 0)
-  #error "You cannot define paddle_left or paddle_right as 0 to disable"
+#if !defined ARDUINO_RP2040
+  #if (paddle_left == 0) || (paddle_right == 0)
+    #error "You cannot define paddle_left or paddle_right as 0 to disable"
+  #endif
 #endif
-
 #if defined(FEATURE_BUTTONS)
   #include "src/buttonarray/buttonarray.h"
 #endif
@@ -2302,6 +2311,9 @@ void setup()
   // initialize_serial_ports();        // Goody - this is available for testing startup issues
   // initialize_debug_startup();       // Goody - this is available for testing startup issues
   // debug_blink();                    // Goody - this is available for testing startup issues
+  #if defined(ARDUINO_RP2040)
+  EEPROM.begin(1024);
+  #endif
   initialize_keyer_state();
   initialize_potentiometer();
   initialize_rotary_encoder();
@@ -6291,7 +6303,7 @@ void service_async_eeprom_write(){
       } else { // we're done
         async_eeprom_write = 0;
         last_async_eeprom_write_status = 0;
-        #if defined(ARDUINO_SAMD_VARIANT_COMPLIANCE)
+        #if defined(ARDUINO_SAMD_VARIANT_COMPLIANCE) || defined(ARDUINO_RP2040)
           EEPROM.commit();
         #endif
 
@@ -16342,7 +16354,7 @@ void serial_program_memory(PRIMARY_SERIAL_CLS * port_to_use)
     port_to_use->println(F("\n\rError"));
   }
 
-  #if defined(ARDUINO_SAMD_VARIANT_COMPLIANCE)
+  #if defined(ARDUINO_SAMD_VARIANT_COMPLIANCE)|| defined(ARDUINO_RP2040)
     EEPROM.commit();
   #endif
 
@@ -17154,7 +17166,7 @@ byte play_memory(byte memory_number) {
 
 
   } //for (int y = (memory_start(memory_number)); (y < (memory_end(memory_number)+1)); y++)
-
+return 0;
 }
 #endif
 
@@ -18050,7 +18062,6 @@ void initialize_keyer_state(){
       memory_area_end = 1024; // not sure if this is a valid assumption
     #endif
   #endif
-
 }
 
 //---------------------------------------------------------------------

--- a/k3ng_keyer/keyer_features_and_options_opencwkeyer_mk3.h
+++ b/k3ng_keyer/keyer_features_and_options_opencwkeyer_mk3.h
@@ -1,0 +1,131 @@
+// compile time features and options - comment or uncomment to add or delete features
+// FEATURES add more bytes to the compiled binary, OPTIONS change code behavior
+
+#define ARDUINO_RP2040
+#define FEATURE_BUTTONS
+#define FEATURE_COMMAND_MODE
+#define FEATURE_COMMAND_LINE_INTERFACE  // Command Line Interface functionality
+#define FEATURE_MEMORIES             // on the Arduino Due, you must have FEATURE_EEPROM_E24C1024 and E24C1024 EEPROM hardware in order to compile this
+#define FEATURE_MEMORY_MACROS
+//#define FEATURE_WINKEY_EMULATION    // disabling Automatic Software Reset is highly recommended (see documentation)
+#define FEATURE_BEACON                // Go into beacon mode if paddle_left pin is LOW at boot up
+#define FEATURE_BEACON_SETTING        // Go into beacon mode at boot up if EEPROM setting is enabled (\_ CLI Command)
+#define FEATURE_TRAINING_COMMAND_LINE_INTERFACE
+#define FEATURE_POTENTIOMETER         // do not enable unless you have a potentiometer connected, otherwise noise will falsely trigger wpm changes
+// #define FEATURE_SIDETONE_SWITCH   // adds switch control for the sidetone output. requires an external toggle switch (assigned to an arduino pin - see keyer_pin_settings.h). 
+// #define FEATURE_SIDETONE_NEWTONE      // Use the NewTone library, ~1k smaller code size than the standard tone library. Uses timer1 (pins 9 or 10)  https://bitbucket.org/teckel12/arduino-new-tone/wiki/Home
+#define FEATURE_SERIAL_HELP
+// #define FEATURE_HELL
+// #define FEATURE_PS2_KEYBOARD        // Use a PS2 keyboard to send code - Change keyboard layout (non-US) in K3NG_PS2Keyboard.h.  Additional options below.
+// #define FEATURE_USB_KEYBOARD          // Use a USB keyboard to send code - Uncomment three lines in k3ng_keyer.ino (search for note_usb_uncomment_lines)
+// #define FEATURE_CW_COMPUTER_KEYBOARD  // Have an Arduino Due or Leonardo act as a USB HID (Human Interface Device) keyboard and use the paddle to "type" characters on the computer -- uncomment this line in ino file: #include <Keyboard.h>
+// #define FEATURE_DEAD_OP_WATCHDOG
+// #define FEATURE_AUTOSPACE
+// #define FEATURE_FARNSWORTH
+// #define FEATURE_DL2SBA_BANKSWITCH       // Switch memory banks feature as described here: http://dl2sba.com/index.php?option=com_content&view=article&id=131:nanokeyer&catid=15:shack&Itemid=27#english
+// #define FEATURE_LCD_4BIT                // classic LCD disidefplay using 4 I/O lines
+// #define FEATURE_LCD_8BIT                // classic LCD display using 8 I/O lines
+// #define FEATURE_LCD_ADAFRUIT_I2C          // Adafruit I2C LCD display using MCP23017 at addr 0x20
+// #define FEATURE_LCD_ADAFRUIT_BACKPACK    // Adafruit I2C LCD Backup using MCP23008 (courtesy Josiah Ritchie, KE0BLL)
+// #define FEATURE_LCD_YDv1                // YourDuino I2C LCD display with old LCM 1602 V1 ic
+// #define FEATURE_LCD1602_N07DH      // http://linksprite.com/wiki/index.php5?title=16_X_2_LCD_Keypad_Shield_for_Arduino
+// #define FEATURE_LCD_SAINSMART_I2C
+// #define FEATURE_LCD_FABO_PCF8574  // https://github.com/FaBoPlatform/FaBoLCD-PCF8574-Library
+// #define FEATURE_LCD_MATHERTEL_PCF8574 // https://github.com/mathertel/LiquidCrystal_PCF8574
+// #define FEATURE_LCD_I2C_FDEBRABANDER //https://github.com/fdebrabander/Arduino-LiquidCrystal-I2C-library
+// #define FEATURE_LCD_HD44780
+// #define FEATURE_CW_DECODER              // https://github.com/k3ng/k3ng_cw_keyer/wiki/385-Feature:-CW-Decoder 
+// #define FEATURE_SLEEP                   // go to sleep after x minutes to conserve battery power (not compatible with Arduino DUE, may have mixed results with Mega and Mega ADK)
+// #define FEATURE_LCD_BACKLIGHT_AUTO_DIM  // turn off LCD backlight and/or dim Power Indicator LED after x minutes (LED requires a PWM pin)
+// #define FEATURE_ROTARY_ENCODER          // rotary encoder speed control
+// #define FEATURE_CMOS_SUPER_KEYER_IAMBIC_B_TIMING
+// #define FEATURE_USB_MOUSE               // Uncomment three lines in k3ng_keyer.ino (search for note_usb_uncomment_lines)
+// #define FEATURE_CAPACITIVE_PADDLE_PINS  // remove the bypass capacitors on the paddle_left and paddle_right lines when using capactive paddles
+// #define FEATURE_LED_RING                // Mayhew Labs Led Ring support
+// #define FEATURE_ALPHABET_SEND_PRACTICE  // enables command mode S command - created by Ryan, KC2ZWM
+// #define FEATURE_COMMAND_MODE_PROGRESSIVE_5_CHAR_ECHO_PRACTICE // enables command mode U
+// #define FEATURE_PTT_INTERLOCK 
+// #define FEATURE_QLF
+// #define FEATURE_EEPROM_E24C1024
+// #define FEATURE_STRAIGHT_KEY
+// #define FEATURE_DYNAMIC_DAH_TO_DIT_RATIO
+#define FEATURE_PADDLE_ECHO
+#define FEATURE_STRAIGHT_KEY_ECHO
+// #define FEATURE_AMERICAN_MORSE
+// #define FEATURE_4x4_KEYPAD          // code contributed by Jack, W0XR - documentation: https://github.com/k3ng/k3ng_cw_keyer/wiki/380-Feature:-Keypad
+// #define FEATURE_3x4_KEYPAD          // code contributed by Jack, W0XR - documentation: https://github.com/k3ng/k3ng_cw_keyer/wiki/380-Feature:-Keypad
+// #define FEATURE_SEQUENCER
+// #define FEATURE_SD_CARD_SUPPORT
+// #define FEATURE_COMMAND_MODE_ENHANCED_CMD_ACKNOWLEDGEMENT
+// #define FEATURE_WEB_SERVER      // Details: https://github.com/k3ng/k3ng_cw_keyer/wiki/390-Feature:-Ethernet,-Web-Server,-and-Internet-Linking
+// #define FEATURE_INTERNET_LINK   // Details: https://github.com/k3ng/k3ng_cw_keyer/wiki/390-Feature:-Ethernet,-Web-Server,-and-Internet-Linking
+
+// #define FEATURE_COMMAND_LINE_INTERFACE_ON_SECONDARY_PORT     // Activate the Command Line interface on the secondary serial port
+#define OPTION_PRIMARY_SERIAL_PORT_DEFAULT_WINKEY_EMULATION  // Use when activating both FEATURE_WINKEY_EMULATION and FEATURE_COMMAND_LINE_INTERFACE 
+                                                             //    simultaneously.  This will make Winkey emulation be the default at boot up; 
+                                                             //    hold command button down at boot up to activate CLI mode
+
+// #define OPTION_SUPPRESS_SERIAL_BOOT_MSG
+#define OPTION_INCLUDE_PTT_TAIL_FOR_MANUAL_SENDING
+#define OPTION_EXCLUDE_PTT_HANG_TIME_FOR_MANUAL_SENDING
+// #define OPTION_WINKEY_DISCARD_BYTES_AT_STARTUP     // if ASR is not disabled, you may need this to discard errant serial port bytes at startup
+// #define OPTION_WINKEY_STRICT_EEPROM_WRITES_MAY_WEAR_OUT_EEPROM // with this activated the unit will write non-volatile settings to EEPROM when set by Winkey commands
+// #define OPTION_WINKEY_SEND_WORDSPACE_AT_END_OF_BUFFER
+#define OPTION_WINKEY_STRICT_HOST_OPEN               // require an admin host open Winkey command before doing any other commands
+#define OPTION_WINKEY_2_SUPPORT                      // comment out to revert to Winkey version 1 emulation
+#define OPTION_WINKEY_INTERRUPTS_MEMORY_REPEAT
+//#define OPTION_WINKEY_UCXLOG_9600_BAUD              // use this only with UCXLog configured for Winkey 9600 baud mode
+#define OPTION_WINKEY_2_HOST_CLOSE_NO_SERIAL_PORT_RESET  // (Required for Win-Test to function)
+// #define OPTION_WINKEY_FREQUENT_STATUS_REPORT         // activate this to make Winkey emulation play better with RUMlog and RUMped
+#define OPTION_WINKEY_IGNORE_LOWERCASE               // Enable for typical K1EL Winkeyer behavior (use for SkookumLogger version 1.10.14 and prior to workaround "r" bug)
+// #define OPTION_WINKEY_BLINK_PTT_ON_HOST_OPEN
+// #define OPTION_WINKEY_SEND_VERSION_ON_HOST_CLOSE
+// #define OPTION_WINKEY_PINCONFIG_PTT_CONTROLS_PTT_LINE  // Have Winkeyer PTT setting activate/deactivate PTT line rather than control buffered character PTT hold 
+// #define OPTION_REVERSE_BUTTON_ORDER                // This is mainly for the DJ0MY NanoKeyer http://nanokeyer.wordpress.com/
+#define OPTION_PROG_MEM_TRIM_TRAILING_SPACES         // trim trailing spaces from memory when programming in command mode
+#define OPTION_DIT_PADDLE_NO_SEND_ON_MEM_RPT         // this makes dit paddle memory interruption a little smoother
+// #define OPTION_MORE_DISPLAY_MSGS                     // additional optional display messages - comment out to save memory
+// #define OPTION_WATCHDOG_TIMER                        // this enables a four second ATmega48/88/168/328 watchdog timer; use for unattended/remote operation only
+// #define OPTION_MOUSE_MOVEMENT_PADDLE               // experimental (just fooling around) - mouse movement will act like a paddle
+// #define OPTION_NON_ENGLISH_EXTENSIONS  // add support for additional CW characters (i.e. À, Å, Þ, etc.)
+// #define OPTION_DISPLAY_NON_ENGLISH_EXTENSIONS  // LCD display suport for non-English (NO/DK/DE) characters - Courtesy of OZ1JHM
+// #define OPTION_UNKNOWN_CHARACTER_ERROR_TONE
+// #define OPTION_DO_NOT_SAY_HI
+// #define OPTION_PS2_NON_ENGLISH_CHAR_LCD_DISPLAY_SUPPORT // makes some non-English characters from the PS2 keyboard display correctly in the LCD display (donated by Marcin sp5iou)
+// #define OPTION_PS2_KEYBOARD_RESET // reset the PS2 keyboard upon startup with 0xFF (contributed by Bill, W9BEL)
+// #define OPTION_SAVE_MEMORY_NANOKEYER
+// #define OPTION_CW_KEYBOARD_CAPSLOCK_BEEP
+// #define OPTION_CW_KEYBOARD_ITALIAN
+// #define OPTION_CW_KEYBOARD_GERMAN
+// #define OPTION_CW_DECODER_GOERTZEL_AUDIO_DETECTOR
+// #define OPTION_INVERT_PADDLE_PIN_LOGIC
+// #define OPTION_ADVANCED_SPEED_DISPLAY //enables "nerd" speed visualization on display: wpm, cpm (char per min), duration of dit and dah in milliseconds and ratio (contributed by Giorgio, IZ2XBZ)
+// #define OPTION_PROSIGN_SUPPORT    // additional prosign support for paddle and straight key echo on display, CLI, and in memory storage
+// #define OPTION_RUSSIAN_LANGUAGE_SEND_CLI // Russian language CLI sending support (contributed by Павел Бирюков, UA1AQC)
+#define OPTION_DO_NOT_SEND_UNKNOWN_CHAR_QUESTION
+// #define OPTION_CMOS_SUPER_KEYER_IAMBIC_B_TIMING_ON_BY_DEFAULT
+// #define OPTION_SIDETONE_DIGITAL_OUTPUT_NO_SQUARE_WAVE
+
+// #define OPTION_DIRECT_PADDLE_PIN_READS_MEGA   // only works with Mega and pins 2 and 5 - minor performance increase
+// #define OPTION_DIRECT_PADDLE_PIN_READS_UNO    // Unos or Nanos pins 2 and 5 - do not enable on a nanoKeyer, it uses different pins
+
+// #define OPTION_WORDSWORTH_CZECH
+// #define OPTION_WORDSWORTH_DEUTSCH
+// #define OPTION_WORDSWORTH_NORSK
+
+//#define OPTION_EXCLUDE_EXTENDED_CLI_COMMANDS
+
+// #define OPTION_DFROBOT_LCD_COMMAND_BUTTONS
+
+// #define OPTION_EXCLUDE_MILL_MODE
+// #define OPTION_NO_ULTIMATIC // reduce memory usage by removing ultimatic code.
+
+// #define OPTION_DISABLE_SERIAL_PORT_CHECKING_WHILE_SENDING_CW
+// #define OPTION_PERSONALIZED_STARTUP_SCREEN        // displays a user defined string of characters on the second or fourth row of the screen during startup. 1602 display requires OPTION_DO_NOT_SAY_HI
+// #define OPTION_SWAP_PADDLE_PARAMETER_CHANGE_DIRECTION        // reverses the up/down direction when using the paddles to change the wpm or sidetone frequency
+// #define OPTION_DISPLAY_MEMORY_CONTENTS_COMMAND_MODE
+
+// #define OPTION_BEACON_MODE_MEMORY_REPEAT_TIME        // to space out the repeated playing of memory 1 when in beacon mode
+// #define OPTION_BEACON_MODE_PTT_TAIL_TIME             // adds the ptt tail time to each playing of memory 1 in beacon mode
+
+// #define OPTION_WINKEY_PROSIGN_COMPATIBILITY  // Additional character mappings to support K1EL Winkey emulation prosigns

--- a/k3ng_keyer/keyer_hardware.h
+++ b/k3ng_keyer/keyer_hardware.h
@@ -26,6 +26,8 @@
 // #define HARDWARE_K5BCQ   // edit these files: keyer_pin_settings_k5bcq.h, keyer_features_and_options_k5bcq.h, keyer_settings_k5bcq.h 
 // #define HARDWARE_MEGAKEYER // https://github.com/w6ipa/megakeyer
 // #define HARDWARE_OPENCWKEYER_MK2 // https://github.com/ok1cdj/OpenCWKeyerMK2  edit these files: keyer_features_and_options_opencwkeyer_mk2.h keyer_pin_settings_opencwkeyer_mk2.h keyer_settings_opencwkeyer_mk2.h
+#define HARDWARE_OPENCWKEYER_MK3 // https://github.com/ok1cdj/OpenCWKeyerMK3  edit these files: keyer_features_and_options_opencwkeyer_mk3.h keyer_pin_settings_opencwkeyer_mk3.h keyer_settings_opencwkeyer_mk3.h
+
 // #define HARDWARE_IZ3GME // https://github.com/iz3gme/k3ng_cw_keyer  edit these files: keyer_features_and_options_iz3gme.h keyer_pin_settings_iz3gme.h keyer_settings.h
 // #define HARDWARE_YCCC_SO2R_MINI // edit these files: keyer_pin_settings_yccc_so2r_mini.h, keyer_settings_yccc_so2r_mini.h, keyer_features_and_options_yccc_so2r_mini.h
 // #define HARDWARE_TEST_EVERYTHING

--- a/k3ng_keyer/keyer_pin_settings_opencwkeyer_mk3.h
+++ b/k3ng_keyer/keyer_pin_settings_opencwkeyer_mk3.h
@@ -1,0 +1,165 @@
+/* Pins - you must review these and configure ! */
+#ifndef keyer_pin_settings_h
+#define keyer_pin_settings_h
+
+
+#define paddle_left D8
+#define paddle_right D7
+#define tx_key_line_1 D9      // (high = key down/tx on)
+#define tx_key_line_2 0
+#define tx_key_line_3 0
+#define tx_key_line_4 0
+#define tx_key_line_5 0
+#define tx_key_line_6 0
+#define sidetone_line D6         // connect a speaker for sidetone
+#define potentiometer A3        // Speed potentiometer (0 to 5 V) Use pot from 1k to 10k
+#define ptt_tx_1 D10              // PTT ("push to talk") lines
+#define ptt_tx_2 0             //   Can be used for keying fox transmitter, T/R switch, or keying slow boatanchors
+#define ptt_tx_3 0              //   These are optional - set to 0 if unused
+#define ptt_tx_4 0
+#define ptt_tx_5 0
+#define ptt_tx_6 0
+#define tx_key_dit 0            // if defined, goes active for dit (any transmitter) - customized with tx_key_dit_and_dah_pins_active_state and tx_key_dit_and_dah_pins_inactive_state
+#define tx_key_dah 0            // if defined, goes active for dah (any transmitter) - customized with tx_key_dit_and_dah_pins_active_state and tx_key_dit_and_dah_pins_inactive_state
+
+#define potentiometer_enable_pin 0  // if defined, the potentiometer will be enabled only when this pin is held low; set to 0 to ignore this pin
+
+#ifdef FEATURE_BUTTONS
+  #define analog_buttons_pin A2
+  #define command_mode_active_led LED_BUILTIN
+#endif //FEATURE_BUTTONS
+
+/*
+FEATURE_SIDETONE_SWITCH
+  Enabling this feature and an external toggle switch  adds switch control for playing cw sidetone.
+  ST Switch status is displayed in the status command.  This feature will override the software control of the sidetone (\o).
+  Arduino pin is assigned by SIDETONE_SWITCH 
+*/
+
+#ifdef FEATURE_SIDETONE_SWITCH
+  #define SIDETONE_SWITCH 8
+#endif //FEATURE_SIDETONE_SWITCH
+
+
+//lcd pins
+#if defined(FEATURE_LCD_4BIT) || defined(FEATURE_LCD_8BIT)
+  #define lcd_rs A2
+  #define lcd_enable 10  // pin 10 is used by Ethernet shield and will conflict with that
+  #define lcd_d4 6
+  #define lcd_d5 7
+  #define lcd_d6 8
+  #define lcd_d7 9
+#endif //FEATURE_LCD_4BIT || defined(FEATURE_LCD_8BIT)
+
+#if defined(FEATURE_LCD_8BIT) // addition four data lines for 8 bit LCD control
+  #define lcd_d0 20
+  #define lcd_d1 21
+  #define lcd_d2 22
+  #define lcd_d3 23
+#endif //FEATURE_LCD_4BIT || defined(FEATURE_LCD_8BIT)
+
+#ifdef FEATURE_LCD1602_N07DH
+  #define lcd_rs 8
+  #define lcd_enable 9
+  #define lcd_d4 4
+  #define lcd_d5 5
+  #define lcd_d6 6
+  #define lcd_d7 7
+#endif //FEATURE_LCD1602_N07DH
+
+//ps2 keyboard pins
+#ifdef FEATURE_PS2_KEYBOARD
+  #define ps2_keyboard_data A3
+  #define ps2_keyboard_clock 3    // this must be on an interrupt capable pin!
+#endif //FEATURE_PS2_KEYBOARD
+
+// rotary encoder pins and options - rotary encoder code from Jim Balls M0CKE
+#ifdef FEATURE_ROTARY_ENCODER
+  #define OPTION_ENCODER_HALF_STEP_MODE     // Half-step mode?
+  #define rotary_pin1 0                      // CW Encoder Pin
+  #define rotary_pin2 0                    // CCW Encoder Pin
+  #define OPTION_ENCODER_ENABLE_PULLUPS     // define to enable weak pullups.
+#endif //FEATURE_ROTARY_ENCODER
+
+#ifdef FEATURE_LED_RING
+  #define led_ring_sdi    A10 //2    //Data
+  #define led_ring_clk    A9 //3    //Clock
+  #define led_ring_le     A8 //4    //Latch
+#endif //FEATURE_LED_RING
+
+#define correct_answer_led 0
+#define wrong_answer_led 0
+
+#ifdef FEATURE_PTT_INTERLOCK
+  #define ptt_interlock 0  // this pin disables PTT and TX KEY
+#endif //FEATURE_PTT_INTERLOCK
+
+#ifdef FEATURE_STRAIGHT_KEY
+  #define pin_straight_key 52
+#endif //FEATURE_STRAIGHT_KEY
+
+// FEATURE_CW_DECODER & OPTION_CW_DECODER_GOERTZEL_AUDIO_DETECTOR
+// See https://github.com/k3ng/k3ng_cw_keyer/wiki/385-Feature:-CW-Decoder for details
+#define cw_decoder_pin 0             // This is for use with external decoding hardware
+#define cw_decoder_audio_input_pin 0 // This is for audio detection decoding using OPTION_CW_DECODER_GOERTZEL_AUDIO_DETECTOR; this must be an analog pin!
+#define cw_decoder_indicator 0       // Output - goes HIGH when cw tone is detected by OPTION_CW_DECODER_GOERTZEL_AUDIO_DETECTOR
+
+
+#if defined(FEATURE_COMPETITION_COMPRESSION_DETECTION)
+  #define compression_detection_pin 13
+#endif //FEATURE_COMPETITION_COMPRESSION_DETECTION
+
+#if defined(FEATURE_SLEEP)
+  #define keyer_awake 0
+#endif
+
+#if defined(FEATURE_LCD_BACKLIGHT_AUTO_DIM)
+  #define keyer_power_led 0   // must be a PWM-capable pin
+#endif
+
+#if defined(FEATURE_CAPACITIVE_PADDLE_PINS)
+  #define capactive_paddle_pin_inhibit_pin 0     // if this pin is defined and is set high, the capacitive paddle pins will switch to normal (non-capacitive) sensing mode
+#endif
+
+#ifdef FEATURE_4x4_KEYPAD
+  #define Row3 33
+  #define Row2 32
+  #define Row1 31
+  #define Row0 30
+  #define Col3 37
+  #define Col2 36
+  #define Col1 35
+  #define Col0 34
+#endif
+
+#ifdef FEATURE_3x4_KEYPAD
+  #define Row3 33
+  #define Row2 32
+  #define Row1 31
+  #define Row0 30
+  #define Col2 36
+  #define Col1 35
+  #define Col0 34
+#endif
+
+#ifdef FEATURE_SEQUENCER
+  #define sequencer_1_pin 0
+  #define sequencer_2_pin 0
+  #define sequencer_3_pin 0
+  #define sequencer_4_pin 0
+  #define sequencer_5_pin 0
+#endif //FEATURE_SEQUENCER
+
+#define ptt_input_pin 0
+
+#define tx_inhibit_pin 0
+#define tx_pause_pin 0   
+
+#define pin_sending_mode_automatic 0  // goes HIGH when keyer is sending code automatically
+#define pin_sending_mode_manual 0     // goes HIGH when keyer is sending code manually (i.e. the paddle or straight key)
+
+#else
+
+  #error "Multiple pin_settings.h files included somehow..."
+
+#endif //keyer_pin_settings_h


### PR DESCRIPTION
Support of Raspberry PI PICO CPU (RP2040) and new hardware OpenCW Keyer MK3 based on  Seeed Studio XIAO RP2040. 
If you would like to use the RP2040 board, you need to enable #define ARDUINO_RP2040.  There are only changes around EEPROM and HW definition.
This first commit needs extensive testing.