### PR TITLE
Update keyer_pin_settings_opencwkeyer_mk2.h

### DIFF
--- a/k3ng_keyer/keyer_pin_settings_opencwkeyer_mk2.h
+++ b/k3ng_keyer/keyer_pin_settings_opencwkeyer_mk2.h
@@ -6,7 +6,7 @@
 #define paddle_left 2
 #define paddle_right 6
 #define tx_key_line_1 11      // (high = key down/tx on)
-#define tx_key_line_2 13
+#define tx_key_line_2 0
 #define tx_key_line_3 0
 #define tx_key_line_4 0
 #define tx_key_line_5 0
@@ -14,7 +14,7 @@
 #define sidetone_line 4         // connect a speaker for sidetone
 #define potentiometer A0        // Speed potentiometer (0 to 5 V) Use pot from 1k to 10k
 #define ptt_tx_1 12              // PTT ("push to talk") lines
-#define ptt_tx_2 13             //   Can be used for keying fox transmitter, T/R switch, or keying slow boatanchors
+#define ptt_tx_2 0              //   Can be used for keying fox transmitter, T/R switch, or keying slow boatanchors
 #define ptt_tx_3 0              //   These are optional - set to 0 if unused
 #define ptt_tx_4 0
 #define ptt_tx_5 0


### PR DESCRIPTION
The Open CW Keyer MK2 does not have any circuitry to support a second transmitter. Clearing the pin defines for this non-existent transmitter removes the possibility of the user accidentally having tx2 enabled. A long press of the memory 2 button will set the keyer up for tx2 output and there is no indication that this is the configuration. With no pins for tx2 then inadvertently selecting tx2 is not possible.