### PR TITLE
Fix not working DFRobot LCD Keypad buttons

### DIFF
--- a/k3ng_keyer/k3ng_keyer.ino
+++ b/k3ng_keyer/k3ng_keyer.ino
@@ -9244,7 +9244,7 @@ void initialize_analog_button_array() {
     button_array.Add(8,5);
     button_array.Add(9,4);
 
-  #elseif defined(OPTION_DFROBOT_LCD_COMMAND_BUTTONS)
+  #elif defined(OPTION_DFROBOT_LCD_COMMAND_BUTTONS)
     button_array.Add(0,dfrobot_btnSELECT, dfrobot_btnLEFT_analog, dfrobot_btnSELECT_analog);
     button_array.Add(1,dfrobot_btnLEFT, dfrobot_btnDOWN_analog, dfrobot_btnLEFT_analog);
     button_array.Add(2,dfrobot_btnDOWN, dfrobot_btnUP_analog, dfrobot_btnDOWN_analog);


### PR DESCRIPTION
If you're trying to use the DFRobot LCD Keypad, you may run into an issue where the buttons don’t work as they should. You just need to fix this small bug to resolve the problem.